### PR TITLE
A new option for insecure HTTPS(SSL) connection.

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -108,6 +108,12 @@ command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -t {{time}} {{
 # Default: http://mhtest.virtuos.uos.de:8080
 url              = 'http://mhtest.virtuos.uos.de:8080'
 
+# Analogue of -k, --insecure option in curl. Allows insercure SSL connections
+# while using HTTPS on the server.
+# Type: boolean
+# Default: False
+#insecure         = False
+
 # Username for the admin server (digest authentication)
 # Type: string
 # Default: matterhorn_system_account

--- a/pyca/ca.py
+++ b/pyca/ca.py
@@ -254,6 +254,8 @@ def http_request(endpoint, post_data=None):
     curl = pycurl.Curl()
     url = '%s%s' % (config['server']['url'], endpoint)
     curl.setopt(curl.URL, url.encode('ascii', 'ignore'))
+    if config.insecure:
+        curl.setopt(curl.SSL_VERIFYPEER, 0)
     if post_data:
         curl.setopt(curl.HTTPPOST, post_data)
     curl.setopt(curl.WRITEFUNCTION, buf.write)

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -21,6 +21,7 @@ preview          = list(default=list())
 
 [server]
 url              = string(default='http://mhtest.virtuos.uos.de:8080')
+insecure         = boolean(default=False)
 username         = string(default='matterhorn_system_account')
 password         = string(default='CHANGE_ME')
 


### PR DESCRIPTION
Disables SSL certificate checking.

I test some system with Matterhorn which runs on the server with configured HTTPS.  And I need a possibility to not verify the certificate.
Feel free to change anything you want or provide your own implementation of this feature/option.
