### PR TITLE
Changed default recording_state from upcoming to unknown

### DIFF
--- a/pyca/ca.py
+++ b/pyca/ca.py
@@ -77,7 +77,7 @@ def register_ca(status='idle'):
     return True
 
 
-def recording_state(recording_id, status='upcoming'):
+def recording_state(recording_id, status='unknown'):
     '''Send the state of the current recording to the Matterhorn core.
 
     :param recording_id: ID of the current recording


### PR DESCRIPTION
Updating the recording_state with 'upcoming' fails, as there is no such state in matterhorn-core

see: https://bitbucket.org/opencast-community/matterhorn/raw/master/modules/matterhorn-capture-admin-service-api/src/main/java/org/opencastproject/capture/admin/api/RecordingState.java

/*\* The collection of all known states. TODO: Remove this when the states are replaced with enums */
  List<String> KNOWN_STATES = Arrays.asList(new String[] { UNKNOWN, CAPTURING, CAPTURE_FINISHED, CAPTURE_ERROR,
          MANIFEST, MANIFEST_ERROR, MANIFEST_FINISHED, COMPRESSING, COMPRESSING_ERROR, UPLOADING, UPLOAD_FINISHED,
          UPLOAD_ERROR });
