### PR TITLE
Introduce setuptools

### DIFF
--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -39,8 +39,7 @@ def usage(retval=0):
     sys.exit(retval)
 
 
-if __name__ == '__main__':
-
+def main():
     cfg = '/etc/pyca.conf' if os.path.isfile('/etc/pyca.conf') else './etc/pyca.conf'
 
     try:
@@ -73,3 +72,7 @@ if __name__ == '__main__':
     else:
         # Invalid command
         usage(3)
+
+
+if __name__ == '__main__':
+    main()

--- a/readme.rst
+++ b/readme.rst
@@ -35,21 +35,20 @@ Here is a short summary for Debian based OS like Raspian::
 
   git clone https://github.com/lkiesow/pyCA.git
   cd pyCA
-  sudo apt-get install python-virtualenv python-dev libcurl4-gnutls-dev gnutls-dev
+  sudo apt-get install python-virtualenv python-dev libcurl4-gnutls-dev gnutls-dev gcc
   virtualenv venv
-  . ./venv/bin/activate
-  pip install icalendar python-dateutil pycurl configobj
-  vim etc/pyca.conf  <-- Edit the configuration
-  ./start.sh
+  venv/bin/python setup.py install
+  $EDITOR /etc/pyca.conf <-- Edit the configuration
+  venv/bin/pyca
 
 On Fedora::
 
   git clone https://github.com/lkiesow/pyCA.git
   cd pyCA
-  sudo yum install python-pycurl python-dateutil \
-    python-configobj python-icalendar
-  vim etc/pyca.conf  <-- Edit the configuration
-  ./start.sh
+  dnf install python python-setuptools python-pycurl python-dateutil \
+    python-configobj python-icalendar python-flask python setup.py install
+  $EDITOR /etc/pyca.conf <-- Edit the configuration
+  pyca
 
 On RHEL/CentOS 7::
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup
+
+setup(
+    name="pyca",
+    version="1.0.0",
+    description="Opencast Matterhorn capture agent",
+    author="Lars Kiesow",
+    author_email='lkiesow@uos.de',
+    license="LGPLv3",
+    url="https://github.com/lkiesow/pyCA",
+    packages=["pyca"],
+    install_requires=[
+        "icalendar>=3.8.4",
+        "pycurl>=7.19.5",
+        "python-dateutil>=2.4.0",
+        "configobj>=5.0.0",
+        "flask"
+    ],
+    data_files=[("etc", ["etc/pyca.conf"])],
+    entry_points={
+        'console_scripts': [
+            'pyca = pyca.__main__:main'
+        ]
+    }
+)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(
         "configobj>=5.0.0",
         "flask"
     ],
-    data_files=[("etc", ["etc/pyca.conf"])],
     entry_points={
         'console_scripts': [
             'pyca = pyca.__main__:main'


### PR DESCRIPTION
Using python setuptools for building, installation, etc.

The "old" way of installation and starting should still work fine. Also updated the documentation for Fedora and Debian, but not for Centos since it does not seem to work anyway.

I only tested to start this program, but not if it runs properly.
