### PR TITLE
cli command to retry ingesting a recording

### DIFF
--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -19,6 +19,7 @@ Usage %s [OPTIONS] COMMAND
 COMMANDS:
   run  --  Start pyCA as capture agent (default)
   test --  Test recording command
+  reingest [folder] --  Retry ingesting recording in [folder]
   ui   --  Start web based user interface
 
 OPTIONS:
@@ -56,8 +57,8 @@ if __name__ == '__main__':
         usage(1)
 
     # Make sure we got only one command
-    if len(args) > 1:
-        usage(2)
+    #if len(args) > 1:
+    #    usage(2)
 
     cmd = (args + ['run'])[0]
 
@@ -67,6 +68,11 @@ if __name__ == '__main__':
     elif cmd == 'test':
         ca.update_configuration(cfg)
         ca.test()
+    elif cmd == 'reingest':
+        if not len(args) == 2: usage(2)
+        ca.update_configuration(cfg)
+        recording_dir = args[1]
+        ca.reingest(recording_dir)
     elif cmd == 'ui':
         import pyca.ui
         pyca.ui.app.run(host='0.0.0.0')

--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -56,11 +56,11 @@ if __name__ == '__main__':
     except (getopt.GetoptError, ValueError):
         usage(1)
 
-    # Make sure we got only one command
-    #if len(args) > 1:
-    #    usage(2)
-
     cmd = (args + ['run'])[0]
+
+    # Make sure we got only one command
+    if len(args) > 1 and not cmd == 'reingest':
+        usage(2)
 
     if cmd == 'run':
         ca.update_configuration(cfg)

--- a/pyca/ca.py
+++ b/pyca/ca.py
@@ -17,6 +17,7 @@ import icalendar
 import json
 import logging
 import os
+import pickle
 import pycurl
 import sys
 from random import randrange
@@ -250,7 +251,15 @@ def start_capture(event):
         else:
             with open('%s/series.xml' % recording_dir, 'w') as dcfile:
                 dcfile.write(value)
-
+    # write recording information needed for reingesting to disk
+    with open('%s/recording.pyca' % recording_dir, 'wb') as infofile:
+        recording_info = {  'tracks' : tracks,
+                            'recording_dir' : recording_dir,
+                            'recording_id' : recording_id,
+                            'workflow_def' : workflow_def,
+                            'workflow_config' : workflow_config }
+        pickle.dump(recording_info, infofile)
+    
     # If we are a backup CA, we don't want to actually upload anything. So
     # let's just quit here.
     if CONFIG['agent']['backup_mode']:
@@ -476,6 +485,65 @@ def test():
     sys.modules[__name__].http_request = lambda x, y=False: None
     ingest(tracks, directory, '123', 'fast', '')
 
+def reingest(name):
+    ''' Retry ingesting a recording after a failed attempt (e.g. network error)
+    '''
+    # config pyCA as if run() was called
+    if CONFIG['server']['insecure']:
+        logging.warning('INSECURE: HTTPS CHECKS ARE TURNED OFF. A SECURE '
+                        'CONNECTION IS NOT GUARANTEED')
+    if CONFIG['server']['certificate']:
+        try:
+            with open(CONFIG['server']['certificate'], 'r'):
+                pass
+        except IOError as err:
+            logging.warning('Could not read certificate file: %s', err)
+
+    while (not CONFIG.get('service-ingest') or
+           not CONFIG.get('service-capture') or
+           not CONFIG.get('service-scheduler')):
+        try:
+            CONFIG['service-ingest'] = \
+                get_service('org.opencastproject.ingest')
+            CONFIG['service-capture'] = \
+                get_service('org.opencastproject.capture.admin')
+            CONFIG['service-scheduler'] = \
+                get_service('org.opencastproject.scheduler')
+        except pycurl.error:
+            logging.error('Could not get service endpoints. Retrying in 5s')
+            logging.error(traceback.format_exc())
+            time.sleep(5.0)
+
+    while not register_ca():
+        time.sleep(5.0)
+    
+    # retrieve recording information from pickled file
+    logging.info('Trying to reingest %s' % name)
+    
+    recording_dir = '%s/%s' % (CONFIG['capture']['directory'], name)
+    infofile = open('%s/recording.pyca' % recording_dir, 'rb')
+    recording_info = pickle.load(infofile)
+    logging.info('recording id is %s' % recording_info['recording_id'] )
+    
+    # Upload everything
+    register_ca(status='uploading')
+    recording_state(recording_info['recording_id'], 'uploading')
+
+    try:
+        ingest(recording_info['tracks'], recording_info['recording_dir'],
+                recording_info['recording_id'], recording_info['workflow_def'],
+                recording_info['workflow_config'])
+    except:
+        logging.error('Something went wrong during the upload')
+        logging.error(traceback.format_exc())
+        # Update state if something went wrong
+        recording_state(recording_info['recording_id'], 'upload_error')
+        register_ca(status='idle')
+        return False
+    # Update state
+    recording_state(recording_info['recording_id'], 'upload_finished')
+    register_ca(status='idle')
+    return True
 
 def try_mkdir(directory):
     '''Try to create a directory. Pass without error if it already exists.

--- a/pyca/ca.py
+++ b/pyca/ca.py
@@ -253,13 +253,13 @@ def start_capture(event):
                 dcfile.write(value)
     # write recording information needed for reingesting to disk
     with open('%s/recording.pyca' % recording_dir, 'wb') as infofile:
-        recording_info = {  'tracks' : tracks,
-                            'recording_dir' : recording_dir,
-                            'recording_id' : recording_id,
-                            'workflow_def' : workflow_def,
-                            'workflow_config' : workflow_config }
+        recording_info = {'tracks': tracks,
+                          'recording_dir': recording_dir,
+                          'recording_id': recording_id,
+                          'workflow_def': workflow_def,
+                          'workflow_config': workflow_config}
         pickle.dump(recording_info, infofile)
-    
+
     # If we are a backup CA, we don't want to actually upload anything. So
     # let's just quit here.
     if CONFIG['agent']['backup_mode']:
@@ -485,6 +485,7 @@ def test():
     sys.modules[__name__].http_request = lambda x, y=False: None
     ingest(tracks, directory, '123', 'fast', '')
 
+
 def reingest(name):
     ''' Retry ingesting a recording after a failed attempt (e.g. network error)
     '''
@@ -516,23 +517,25 @@ def reingest(name):
 
     while not register_ca():
         time.sleep(5.0)
-    
+
     # retrieve recording information from pickled file
     logging.info('Trying to reingest %s' % name)
-    
+
     recording_dir = '%s/%s' % (CONFIG['capture']['directory'], name)
     infofile = open('%s/recording.pyca' % recording_dir, 'rb')
     recording_info = pickle.load(infofile)
-    logging.info('recording id is %s' % recording_info['recording_id'] )
-    
+    logging.info('recording id is %s' % recording_info['recording_id'])
+
     # Upload everything
     register_ca(status='uploading')
     recording_state(recording_info['recording_id'], 'uploading')
 
     try:
-        ingest(recording_info['tracks'], recording_info['recording_dir'],
-                recording_info['recording_id'], recording_info['workflow_def'],
-                recording_info['workflow_config'])
+        ingest(recording_info['tracks'],
+               recording_info['recording_dir'],
+               recording_info['recording_id'],
+               recording_info['workflow_def'],
+               recording_info['workflow_config'])
     except:
         logging.error('Something went wrong during the upload')
         logging.error(traceback.format_exc())
@@ -544,6 +547,7 @@ def reingest(name):
     recording_state(recording_info['recording_id'], 'upload_finished')
     register_ca(status='idle')
     return True
+
 
 def try_mkdir(directory):
     '''Try to create a directory. Pass without error if it already exists.


### PR DESCRIPTION
Basic code that allows reingesting a existing recording. This can be
used when pyCA failed to upload the recording to the opencast servers
(e.g. network issues, crash, etc.)

After a successful recording, pyCA will create the additional
`recording.pyca` file in the recording directory which holds all
necessary information for ingesting a recording in a python-pickled
format.

Users can then run `./start.sh reingest <name>` to retry ingesting the
recording. The pickled file will then be read and used to call the same
methods.

This code does not have any sane error handling yet, which should be added
further on (especially checks if files and directories exist).
