### PR TITLE
Added unittest framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - export PATH=$PATH:/opt/ffmpeg/
 
 script:
-   - python -m pyca.__main__ test
+   - python -m unittest tests.test_ca
+   - python -m unittest tests.test_db
    - flake8 --ignore=E731 pyca/ca.py
    - flake8 --ignore=E731 pyca/db.py

--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -18,7 +18,6 @@ Usage %s [OPTIONS] COMMAND
 
 COMMANDS:
   run  --  Start pyCA as capture agent (default)
-  test --  Test recording command
   ui   --  Start web based user interface
 
 OPTIONS:
@@ -63,9 +62,6 @@ def main():
     if cmd == 'run':
         config.update_configuration(cfg)
         ca.run()
-    elif cmd == 'test':
-        config.update_configuration(cfg)
-        ca.test()
     elif cmd == 'ui':
         import pyca.ui
         pyca.ui.app.run(host='0.0.0.0')

--- a/pyca/ca.py
+++ b/pyca/ca.py
@@ -474,27 +474,6 @@ def recording_command(directory, name, duration):
     return zip(flavors, files)
 
 
-def test():
-    '''Make a test run doing a 10sec recording.
-    '''
-    logging.info('Starting test recording (10sec)')
-    name = 'test-%i' % get_timestamp()
-    logging.info('Recording name: %s', name)
-    directory = '%s/%s' % (config()['capture']['directory'], name)
-    logging.info('Recording directory: %s', directory)
-    try_mkdir(config()['capture']['directory'])
-    os.mkdir(directory)
-    logging.info('Created recording directory')
-    logging.info('Start recording')
-    tracks = recording_command(directory, name, 2)
-    logging.info('Finished recording')
-
-    logging.info('Testing Ingest')
-    config()['service-ingest'] = ['']
-    sys.modules[__name__].http_request = lambda x, y=False: None
-    ingest(tracks, directory, '123', 'fast', '')
-
-
 def try_mkdir(directory):
     '''Try to create a directory. Pass without error if it already exists.
     '''

--- a/tests/test_ca.py
+++ b/tests/test_ca.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+'''
+Tests for basic capturing
+'''
+
+import unittest
+import logging
+import tempfile
+import shutil
+import sys
+
+from pyca import ca, config
+
+class TestSequenceFunctions(unittest.TestCase):
+
+    def setUp(self):
+        cfg = './etc/pyca.conf'
+        config.update_configuration(cfg)
+
+
+    def test_capture(self):
+        logging.info('Starting test recording (10sec)')
+        directory = tempfile.mkdtemp()
+        try:
+            logging.info('Recording directory: %s', directory)
+            logging.info('Created recording directory')
+            logging.info('Start recording')
+            tracks = ca.recording_command(directory, 'testname', 2)
+            logging.info('Finished recording')
+
+            logging.info('Testing Ingest')
+
+            # Set some ingest endpoint
+            config.config()['service-ingest'] = ['']
+            # Mock http_request method
+            ca.http_request = lambda x, y=False: None
+            ca.ingest(tracks, directory, '123', 'fast', '')
+        finally:
+            shutil.rmtree(directory)
+
+    def test_get_service(self):
+        res = '''{"services":{
+                    "service":{
+                        "type":"org.opencastproject.capture.admin",
+                        "host":"https:\/\/octestallinone.virtuos.uos.de",
+                        "path":"\/capture-admin",
+                        "active":true,
+                        "online":true,
+                        "maintenance":false,
+                        "jobproducer":false,
+                        "onlinefrom":"2016-11-20T02:01:03.525+01:00",
+                        "service_state":"NORMAL",
+                        "state_changed":"2016-11-20T02:01:03.525+01:00",
+                        "error_state_trigger":0,
+                        "warning_state_trigger":0}}}'''.encode('utf-8')
+        # Mock http_request method
+        ca.http_request = lambda x, y=False: res
+        endpoint = u'https://octestallinone.virtuos.uos.de/capture-admin'
+        assert ca.get_service('') == [endpoint]
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+'''
+Tests for database
+'''
+
+import unittest
+import logging
+import tempfile
+import os
+import sys
+
+from pyca import db, config
+
+class TestSequenceFunctions(unittest.TestCase):
+
+    dbfile = None
+
+    def setUp(self):
+        cfg = './etc/pyca.conf'
+        config.update_configuration(cfg)
+
+        _, self.dbfile = tempfile.mkstemp()
+        config.config()['agent']['database'] = 'sqlite:///' + self.dbfile
+
+    def tearDown(self):
+        os.remove(self.dbfile)
+
+    def test_get_service(self):
+        assert 'autocommit' in db.get_session().__dict__.keys()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
To make sure everything works properly with both Python 2 and 3 we need
unit tests covering more that just the basic test that was in place
before. This patch adds the first parts of a test framework.