### PR TITLE
Simplify pyCA Shutdown

### DIFF
--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -12,7 +12,7 @@ import multiprocessing
 import os
 import signal
 import sys
-from pyca import capture, config, schedule, ingest, ui
+from pyca import capture, config, schedule, ingest, ui, utils
 
 USAGE = '''
 Usage %s [OPTIONS] COMMAND
@@ -46,8 +46,7 @@ def usage(retval=0):
 def sigint_handler(signum, frame):
     '''Intercept sigint and terminate services gracefully.
     '''
-    for mod in (capture, ingest, schedule):
-        mod.terminate = True
+    utils.terminate(True)
 
 
 def sigterm_handler(signum, frame):

--- a/pyca/capture.py
+++ b/pyca/capture.py
@@ -9,6 +9,7 @@
 
 from pyca.utils import timestamp, try_mkdir, configure_service, ensurelist
 from pyca.utils import register_ca, recording_state, update_event_status
+from pyca.utils import terminate
 from pyca.config import config
 from pyca.db import get_session, RecordedEvent, UpcomingEvent, Status
 import logging
@@ -22,17 +23,15 @@ import time
 import traceback
 
 
-terminate = False
 captureproc = None
 
 
 def sigterm_handler(signum, frame):
     '''Intercept sigterm and terminate all processes.
     '''
-    global terminate
     if captureproc and captureproc.poll() is None:
         captureproc.terminate()
-    terminate = True
+    terminate(True)
     sys.exit(0)
 
 
@@ -133,7 +132,7 @@ def control_loop():
     '''Main loop of the capture agent, retrieving and checking the schedule as
     well as starting the capture process if necessry.
     '''
-    while not terminate:
+    while not terminate():
         # Get next recording
         register_ca()
         events = get_session().query(UpcomingEvent)\

--- a/pyca/ingest.py
+++ b/pyca/ingest.py
@@ -7,7 +7,7 @@
     :license: LGPL – see license.lgpl for more details.
 '''
 
-from pyca.utils import http_request, configure_service, register_ca
+from pyca.utils import http_request, configure_service, register_ca, terminate
 from pyca.utils import recording_state, update_event_status
 from pyca.config import config
 from pyca.db import get_session, RecordedEvent, Status
@@ -18,9 +18,6 @@ import pycurl
 from random import randrange
 import time
 import traceback
-
-
-terminate = False
 
 
 def get_config_params(properties):
@@ -157,7 +154,7 @@ def control_loop():
     '''Main loop of the capture agent, retrieving and checking the schedule as
     well as starting the capture process if necessry.
     '''
-    while not terminate:
+    while not terminate():
         # Get next recording
         register_ca()
         events = get_session().query(RecordedEvent)\

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -8,6 +8,7 @@
 '''
 
 from pyca.utils import http_request, configure_service, unix_ts, timestamp
+from pyca.utils import terminate
 from pyca.config import config
 from pyca.db import get_session, UpcomingEvent
 from base64 import b64decode
@@ -16,9 +17,6 @@ import dateutil.parser
 import logging
 import time
 import traceback
-
-
-terminate = False
 
 
 def parse_ical(vcal):
@@ -95,7 +93,7 @@ def get_schedule():
 def control_loop():
     '''Main loop, retrieving the schedule.
     '''
-    while not terminate:
+    while not terminate():
         # Try getting an updated schedult
         get_schedule()
         q = get_session().query(UpcomingEvent)\
@@ -107,7 +105,7 @@ def control_loop():
             logging.info('No scheduled recording')
 
         next_update = timestamp() + config()['agent']['update_frequency']
-        while not terminate and timestamp() < next_update:
+        while not terminate() and timestamp() < next_update:
             time.sleep(0.1)
 
     logging.info('Shutting down schedule service')

--- a/pyca/utils.py
+++ b/pyca/utils.py
@@ -198,3 +198,12 @@ def update_event_status(event, status):
                                .update({'status': status})
     event.status = status
     dbs.commit()
+
+
+def terminate(shutdown=None):
+    '''Mark process as to be terminated.
+    '''
+    global _terminate
+    if shutdown is not None:
+        _terminate = shutdown
+    return '_terminate' in globals() and _terminate

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -12,7 +12,7 @@ import tempfile
 import unittest
 
 from pyca import capture, config, db, utils
-from tests.tools import should_fail
+from tests.tools import should_fail, terminate_fn
 
 if sys.version_info.major > 2:
     try:
@@ -77,7 +77,7 @@ class TestPycaCapture(unittest.TestCase):
         assert capture.safe_start_capture(self.event)
 
     def test_run(self):
-        capture.terminate = True
+        capture.terminate = terminate_fn(1)
         capture.run()
 
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -12,7 +12,7 @@ import tempfile
 import unittest
 
 from pyca import ingest, config, db, utils
-from tests.tools import should_fail
+from tests.tools import should_fail, terminate_fn
 
 if sys.version_info.major > 2:
     try:
@@ -82,7 +82,9 @@ class TestPycaIngest(unittest.TestCase):
         assert ingest.safe_start_ingest(1)
 
     def test_run(self):
-        ingest.control_loop = lambda: True
+        ingest.terminate(True)
+        ingest.run()
+        ingest.terminate = terminate_fn(1)
         ingest.run()
 
 

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -10,7 +10,7 @@ import tempfile
 import unittest
 
 from pyca import schedule, config, db, utils
-from tests.tools import should_fail, ShouldFailException
+from tests.tools import should_fail, ShouldFailException, terminate_fn
 
 
 class TestPycaCapture(unittest.TestCase):
@@ -56,7 +56,7 @@ class TestPycaCapture(unittest.TestCase):
         assert db.get_session().query(db.UpcomingEvent).count()
 
     def test_run(self):
-        schedule.terminate = True
+        schedule.terminate = terminate_fn(2)
         schedule.run()
 
 

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -10,3 +10,15 @@ class ShouldFailException(Exception):
 
 def should_fail(*args, **kwargs):
     raise ShouldFailException()
+
+
+def __terminate():
+    global _terminate
+    _terminate -= 1
+    return _terminate < 0
+
+
+def terminate_fn(num):
+    global _terminate
+    _terminate = num
+    return __terminate


### PR DESCRIPTION
This patch introduces a global shutdown method instead of using the
termination variables for every module. That way, it is easier to shut
pyCA down from anywhere in the code.

It also makes testing easier since we can now determine if code should
run through before the termination is triggered instead if having to
assign the value of the termination variable in advance.