### PR TITLE
Fix the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name="pyca",
@@ -8,7 +8,7 @@ setup(
     author_email='lkiesow@uos.de',
     license="LGPLv3",
     url="https://github.com/opencast/pyCA",
-    packages=["pyca"],
+    packages=find_packages(),
     install_requires=[
         "pycurl>=7.19.5",
         "python-dateutil>=2.4.0",

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,6 @@ setup(
         'console_scripts': [
             'pyca = pyca.__main__:main'
         ]
-    }
+    },
+    test_suite="tests",
 )


### PR DESCRIPTION
Currently the setup.py file does not work properly.

 * I fixed this by using find_packages from the setuptools to install pyca.
 * Also I added the test suite, so you can run the tests using

    python setup.py test