### PR TITLE
Introduce configurable logger

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -173,3 +173,8 @@ password         = 'CHANGE_ME'
 # Type: boolean
 # Default: True
 #stderr           = True
+
+# Configure the log level
+# possible values are: debug, info, warning and error
+# Default: info
+#level            = info

--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -160,3 +160,16 @@ password         = 'CHANGE_ME'
 # Type: string
 # Default: http://localhost:5000
 #url              = 'http://localhost:5000'
+
+
+[logging]
+
+# Log to the system logger
+# Type: boolean
+# Default: False
+#syslog           = False
+
+# Log to stderr
+# Type: boolean
+# Default: True
+#stderr           = True

--- a/pyca/__init__.py
+++ b/pyca/__init__.py
@@ -6,12 +6,3 @@
     :copyright: 2014-2015, Lars Kiesow <lkiesow@uos.de>
     :license: LGPL – see license.lgpl for more details.
 '''
-
-import logging
-
-
-# Set up logging
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s %(levelname)-8s ' +
-                    '[%(filename)s:%(lineno)s:%(funcName)s()] %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S')

--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -104,11 +104,11 @@ def main():
         handlers.append(logging.handlers.SysLogHandler(address='/dev/log'))
     if conf['logging']['stderr']:
         handlers.append(logging.StreamHandler(sys.stderr))
-    root_logger = logging.getLogger('')
+    logger = logging.getLogger('')
     for h in handlers:
         h.setFormatter(logging.Formatter(
             'pyca: [%(name)s:%(lineno)s:%(funcName)s()] %(message)s'))
-        root_logger.addHandler(h)
+        logger.addHandler(h)
 
     # evaluate loglevel myself. eval frightened me
     level = conf['logging']['level']
@@ -124,7 +124,7 @@ def main():
         # This is a safeguarding. With proper validation config can only have
         # the above mentioned cases
         level = logging.INFO
-    root_logger.setLevel(level)
+    logger.setLevel(level)
 
     # Set signal handler
     signal.signal(signal.SIGINT, sigint_handler)

--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -107,7 +107,7 @@ def main():
     logger = logging.getLogger('')
     for h in handlers:
         h.setFormatter(logging.Formatter(
-            'pyca: [%(name)s:%(lineno)s:%(funcName)s()] %(message)s'))
+            '[%(name)s:%(lineno)s:%(funcName)s()] %(message)s'))
         logger.addHandler(h)
 
     # evaluate loglevel myself. eval frightened me

--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -105,11 +105,26 @@ def main():
     if conf['logging']['stderr']:
         handlers.append(logging.StreamHandler(sys.stderr))
     root_logger = logging.getLogger('')
-    root_logger.setLevel(logging.INFO)
     for h in handlers:
         h.setFormatter(logging.Formatter(
             'pyca: [%(name)s:%(lineno)s:%(funcName)s()] %(message)s'))
         root_logger.addHandler(h)
+
+    # evaluate loglevel myself. eval frightened me
+    level = conf['logging']['level']
+    if level == 'debug':
+        level = logging.DEBUG
+    elif level == 'info':
+        level = logging.INFO
+    elif level == 'warning':
+        level = logging.WARNING
+    elif level == 'error':
+        level = logging.ERROR
+    else:
+        # This is a safeguarding. With proper validation config can only have
+        # the above mentioned cases
+        level = logging.INFO
+    root_logger.setLevel(level)
 
     # Set signal handler
     signal.signal(signal.SIGINT, sigint_handler)

--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -110,21 +110,7 @@ def main():
             '[%(name)s:%(lineno)s:%(funcName)s()] %(message)s'))
         logger.addHandler(h)
 
-    # evaluate loglevel myself. eval frightened me
-    level = conf['logging']['level']
-    if level == 'debug':
-        level = logging.DEBUG
-    elif level == 'info':
-        level = logging.INFO
-    elif level == 'warning':
-        level = logging.WARNING
-    elif level == 'error':
-        level = logging.ERROR
-    else:
-        # This is a safeguarding. With proper validation config can only have
-        # the above mentioned cases
-        level = logging.INFO
-    logger.setLevel(level)
+    logger.setLevel(logging.getLevelName(conf['logging']['level'].upper()))
 
     # Set signal handler
     signal.signal(signal.SIGINT, sigint_handler)

--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -108,7 +108,7 @@ def main():
     root_logger.setLevel(logging.INFO)
     for h in handlers:
         h.setFormatter(logging.Formatter(
-            'pyca: [%(filename)s:%(lineno)s:%(funcName)s()] %(message)s'))
+            'pyca: [%(name)s:%(lineno)s:%(funcName)s()] %(message)s'))
         root_logger.addHandler(h)
 
     # Set signal handler

--- a/pyca/agentstate.py
+++ b/pyca/agentstate.py
@@ -14,6 +14,8 @@ from pyca.db import Service, ServiceStatus
 import logging
 import time
 
+logger = logging.getLogger('__main__')
+
 
 def control_loop():
     '''Main loop, updating the capture agent state.
@@ -26,7 +28,7 @@ def control_loop():
         while not terminate and timestamp() < next_update:
             time.sleep(0.1)
 
-    logging.info('Shutting down agentstate service')
+    logger.info('Shutting down agentstate service')
     set_service_status(Service.AGENTSTATE, ServiceStatus.STOPPED)
 
 

--- a/pyca/agentstate.py
+++ b/pyca/agentstate.py
@@ -14,7 +14,7 @@ from pyca.db import Service, ServiceStatus
 import logging
 import time
 
-logger = logging.getLogger('__main__')
+logger = logging.getLogger(__name__)
 
 
 def control_loop():

--- a/pyca/capture.py
+++ b/pyca/capture.py
@@ -23,7 +23,7 @@ import sys
 import time
 import traceback
 
-
+logger = logging.getLogger('__main__')
 captureproc = None
 
 
@@ -40,7 +40,7 @@ def start_capture(event):
     '''Start the capture process, creating all necessary files and directories
     as well as ingesting the captured files if no backup mode is configured.
     '''
-    logging.info('Start recording')
+    logger.info('Start recording')
 
     # First move event to recording_event table
     db = get_session()
@@ -68,8 +68,8 @@ def start_capture(event):
         event.set_tracks(tracks)
         db.commit()
     except:
-        logging.error('Recording command failed')
-        logging.error(traceback.format_exc())
+        logger.error('Recording command failed')
+        logger.error(traceback.format_exc())
         # Update state
         recording_state(event.uid, 'capture_error')
         update_event_status(event, Status.FAILED_RECORDING)
@@ -88,8 +88,8 @@ def safe_start_capture(event):
     try:
         return start_capture(event)
     except Exception:
-        logging.error('Start capture failed')
-        logging.error(traceback.format_exc())
+        logger.error('Start capture failed')
+        logger.error(traceback.format_exc())
         recording_state(event.uid, 'capture_error')
         update_event_status(event, Status.FAILED_RECORDING)
         set_service_status_immediate(Service.CAPTURE, ServiceStatus.IDLE)
@@ -105,7 +105,7 @@ def recording_command(directory, name, duration):
     cmd = cmd.replace('{{dir}}', directory)
     cmd = cmd.replace('{{name}}', name)
     cmd = cmd.replace('{{previewdir}}', preview_dir)
-    logging.info(cmd)
+    logger.info(cmd)
     args = shlex.split(cmd)
     captureproc = subprocess.Popen(args)
     while captureproc.poll() is None:
@@ -118,8 +118,8 @@ def recording_command(directory, name, duration):
         try:
             os.remove(preview.replace('{{previewdir}}', preview_dir))
         except OSError:
-            logging.warning('Could not remove preview files')
-            logging.warning(traceback.format_exc())
+            logger.warning('Could not remove preview files')
+            logger.warning(traceback.format_exc())
 
     # Return [(flavor,path),…]
     flavors = ensurelist(config()['capture']['flavors'])
@@ -142,7 +142,7 @@ def control_loop():
         if events.count():
             safe_start_capture(events[0])
         time.sleep(1.0)
-    logging.info('Shutting down capture service')
+    logger.info('Shutting down capture service')
     set_service_status(Service.CAPTURE, ServiceStatus.STOPPED)
 
 

--- a/pyca/capture.py
+++ b/pyca/capture.py
@@ -23,7 +23,7 @@ import sys
 import time
 import traceback
 
-logger = logging.getLogger('__main__')
+logger = logging.getLogger(__name__)
 captureproc = None
 
 

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -42,6 +42,7 @@ url              = string(default='http://localhost:5000')
 [logging]
 syslog           = boolean(default=False)
 stderr           = boolean(default=True)
+level            = option('debug', 'info', 'warning', 'error', default='info')
 '''  # noqa
 
 cfgspec = __CFG.split('\n')

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -68,7 +68,7 @@ def check():
     '''
     if config()['server']['insecure']:
         logger.warning('INSECURE: HTTPS CHECKS ARE TURNED OFF. A SECURE '
-                        'CONNECTION IS NOT GUARANTEED')
+                       'CONNECTION IS NOT GUARANTEED')
     if config()['server']['certificate']:
         try:
             with open(config()['server']['certificate'], 'rb'):

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -7,6 +7,7 @@ import logging
 from configobj import ConfigObj
 from validate import Validator
 
+logger = logging.getLogger('__name__')
 
 __CFG = '''
 [agent]
@@ -37,6 +38,10 @@ username         = string(default='admin')
 password         = string(default='opencast')
 refresh_rate     = integer(min=1, default=2)
 url              = string(default='http://localhost:5000')
+
+[logging]
+syslog           = boolean(default=False)
+stderr           = boolean(default=True)
 '''  # noqa
 
 cfgspec = __CFG.split('\n')
@@ -61,14 +66,14 @@ def check():
     '''Check configuration for sanity.
     '''
     if config()['server']['insecure']:
-        logging.warning('INSECURE: HTTPS CHECKS ARE TURNED OFF. A SECURE '
+        logger.warning('INSECURE: HTTPS CHECKS ARE TURNED OFF. A SECURE '
                         'CONNECTION IS NOT GUARANTEED')
     if config()['server']['certificate']:
         try:
             with open(config()['server']['certificate'], 'rb'):
                 pass
         except IOError as err:
-            logging.warning('Could not read certificate file: %s', err)
+            logger.warning('Could not read certificate file: %s', err)
 
 
 def config(key=None):

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -7,7 +7,7 @@ import logging
 from configobj import ConfigObj
 from validate import Validator
 
-logger = logging.getLogger('__name__')
+logger = logging.getLogger(__name__)
 
 __CFG = '''
 [agent]

--- a/pyca/ingest.py
+++ b/pyca/ingest.py
@@ -20,7 +20,7 @@ from random import randrange
 import time
 import traceback
 
-logger = logging.getLogger('__main__')
+logger = logging.getLogger(__name__)
 
 
 def get_config_params(properties):

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -103,7 +103,7 @@ def control_loop():
                          .filter(UpcomingEvent.end > timestamp())
         if q.count():
             logger.info('Next scheduled recording: %s',
-                         datetime.fromtimestamp(q[0].start))
+                        datetime.fromtimestamp(q[0].start))
         else:
             logger.info('No scheduled recording')
 

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -18,6 +18,8 @@ import logging
 import time
 import traceback
 
+logger = logging.getLogger('__main__')
+
 
 def parse_ical(vcal):
     '''Parse Opencast schedule iCalendar file and return events as dict
@@ -65,15 +67,15 @@ def get_schedule():
     except Exception as e:
         # Silently ignore the error if the capture agent is not yet registered
         if e.args[1] != 404:
-            logging.error('Could not get schedule')
-            logging.error(traceback.format_exc())
+            logger.error('Could not get schedule')
+            logger.error(traceback.format_exc())
         return
 
     try:
         cal = parse_ical(vcal.decode('utf-8'))
     except Exception:
-        logging.error('Could not parse ical')
-        logging.error(traceback.format_exc())
+        logger.error('Could not parse ical')
+        logger.error(traceback.format_exc())
         return
     db = get_session()
     db.query(UpcomingEvent).delete()
@@ -100,16 +102,16 @@ def control_loop():
         q = get_session().query(UpcomingEvent)\
                          .filter(UpcomingEvent.end > timestamp())
         if q.count():
-            logging.info('Next scheduled recording: %s',
+            logger.info('Next scheduled recording: %s',
                          datetime.fromtimestamp(q[0].start))
         else:
-            logging.info('No scheduled recording')
+            logger.info('No scheduled recording')
 
         next_update = timestamp() + config()['agent']['update_frequency']
         while not terminate() and timestamp() < next_update:
             time.sleep(0.1)
 
-    logging.info('Shutting down schedule service')
+    logger.info('Shutting down schedule service')
     set_service_status(Service.SCHEDULE, ServiceStatus.STOPPED)
 
 

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -18,7 +18,7 @@ import logging
 import time
 import traceback
 
-logger = logging.getLogger('__main__')
+logger = logging.getLogger(__name__)
 
 
 def parse_ical(vcal):

--- a/pyca/utils.py
+++ b/pyca/utils.py
@@ -26,7 +26,7 @@ else:
     from io import BytesIO as bio
 
 
-logger = logging.getLogger('__main__')
+logger = logging.getLogger(__name__)
 
 
 def http_request(url, post_data=None):

--- a/pyca/utils.py
+++ b/pyca/utils.py
@@ -125,7 +125,7 @@ def configure_service(service):
                 get_service('org.opencastproject.' + service)
         except:
             logger.error('Could not get %s endpoint. Retrying in 5 seconds' %
-                          service)
+                         service)
             logger.error(traceback.format_exc())
             time.sleep(5.0)
 

--- a/pyca/utils.py
+++ b/pyca/utils.py
@@ -26,11 +26,7 @@ else:
     from io import BytesIO as bio
 
 
-# Set up logging
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s %(levelname)-8s ' +
-                    '[%(filename)s:%(lineno)s:%(funcName)s()] %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S')
+logger = logging.getLogger('__main__')
 
 
 def http_request(url, post_data=None):
@@ -87,7 +83,7 @@ def get_service(service_type):
     endpoints = [s['host'] + s['path'] for s in services
                  if s['online'] and s['active']]
     for endpoint in endpoints:
-        logging.info(u'Endpoint for %s: %s', service_type, endpoint)
+        logger.info(u'Endpoint for %s: %s', service_type, endpoint)
     return endpoints
 
 
@@ -128,9 +124,9 @@ def configure_service(service):
             config()['service-' + service] = \
                 get_service('org.opencastproject.' + service)
         except:
-            logging.error('Could not get %s endpoint. Retrying in 5 seconds' %
+            logger.error('Could not get %s endpoint. Retrying in 5 seconds' %
                           service)
-            logging.error(traceback.format_exc())
+            logger.error(traceback.format_exc())
             time.sleep(5.0)
 
 
@@ -156,12 +152,12 @@ def register_ca(status='idle'):
     try:
         response = http_request(url, params).decode('utf-8')
         if response:
-            logging.info(response)
+            logger.info(response)
     except:
         # Ignore errors (e.g. network issues) as it's more important to get
         # the recording as to set the correct current state in the admin ui.
-        logging.warning('Could not set capture agent state')
-        logging.warning(traceback.format_exc())
+        logger.warning('Could not set capture agent state')
+        logger.warning(traceback.format_exc())
         return False
     return True
 
@@ -182,12 +178,12 @@ def recording_state(recording_id, status):
     url += '/recordings/%s' % recording_id
     try:
         result = http_request(url, params)
-        logging.info(result)
+        logger.info(result)
     except:
         # Ignore errors (e.g. network issues) as it's more important to get
         # the recording as to set the correct current state in the admin ui.
-        logging.warning('Could not set recording state')
-        logging.warning(traceback.format_exc())
+        logger.warning('Could not set recording state')
+        logger.warning(traceback.format_exc())
 
 
 def update_event_status(event, status):


### PR DESCRIPTION
Introduce a configrable logger to solve #82

It should be possible to

 * enable/disable logging to stderr
 * enable/disable logging to the system logger
 * setting the log level

To not change the standard behavior, I decided to enable stderr logging and disable system logger by default and use log level info. Only the logging formater is changed a little bit by using the `name` rather than the `filename` (`pyca.capture` instead of `capture.py`).

