### PR TITLE
Drop Unnecessary Error

### DIFF
--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -81,15 +81,15 @@ def main():
     # Check command line options
     try:
         opts, args = getopt.getopt(sys.argv[1:], 'hc:', ['help', 'config='])
-
-        for opt, arg in opts:
-            if opt in ("-h", "--help"):
-                usage()
-            if opt in ('-c', '--config'):
-                cfg = arg
-                break
-    except (getopt.GetoptError, ValueError):
+    except getopt.GetoptError:
         usage(1)
+
+    for opt, arg in opts:
+        if opt in ("-h", "--help"):
+            usage()
+        if opt in ('-c', '--config'):
+            cfg = arg
+            break
 
     # Make sure we got only one command
     if len(args) > 1:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,6 +24,11 @@ class TestPycaMain(unittest.TestCase):
             __main__.main()
         except BaseException as e:
             assert e.code == 0
+        sys.argv = ['pyca', '-x']
+        try:
+            __main__.main()
+        except BaseException as e:
+            assert e.code == 1
         sys.argv = ['pyca', 'too', 'many', 'arguments']
         try:
             __main__.main()


### PR DESCRIPTION
This patch fixes #85 and drops the unnecessary ValueError catch
statement as well as shrinking the try-catch block to a minimum.