### PR TITLE
Validate Configuration

### DIFF
--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -95,7 +95,11 @@ def main():
     if len(args) > 1:
         usage(2)
 
-    config.update_configuration(cfg)
+    try:
+        config.update_configuration(cfg)
+    except ValueError as e:
+        print(e.message)
+        sys.exit(3)
 
     # Initialize logger
     handlers = []

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -57,7 +57,9 @@ def update_configuration(cfgfile='/etc/pyca.conf'):
     '''
     cfg = ConfigObj(cfgfile, configspec=cfgspec)
     validator = Validator()
-    cfg.validate(validator)
+    val = cfg.validate(validator)
+    if val is not True:
+        raise ValueError('Invalid configuration: %s' % val)
     globals()['__config'] = cfg
     check()
     return cfg


### PR DESCRIPTION
This patch fixes #86. PyCA now validates it's configuration and refuses
to start up when the configuration is broken.