### PR TITLE
Close Open File-Descriptor

### DIFF
--- a/tests/test_agentstate.py
+++ b/tests/test_agentstate.py
@@ -16,7 +16,7 @@ class TestPycaAgentState(unittest.TestCase):
 
     def setUp(self):
         utils.http_request = lambda x, y=False: b'xxx'
-        _, self.dbfile = tempfile.mkstemp()
+        self.fd, self.dbfile = tempfile.mkstemp()
         config.config()['agent']['database'] = 'sqlite:///' + self.dbfile
         config.config()['service-capture.admin'] = ['']
 
@@ -24,6 +24,7 @@ class TestPycaAgentState(unittest.TestCase):
         db.init()
 
     def tearDown(self):
+        os.close(self.fd)
         os.remove(self.dbfile)
 
     def test_run(self):

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -29,7 +29,7 @@ class TestPycaCapture(unittest.TestCase):
         reload(utils)
         reload(db)
         utils.http_request = lambda x, y=False: b'xxx'
-        _, self.dbfile = tempfile.mkstemp()
+        self.fd, self.dbfile = tempfile.mkstemp()
         self.cadir = tempfile.mkdtemp()
         preview = os.path.join(self.cadir, 'preview.png')
         open(preview, 'a').close()
@@ -60,6 +60,7 @@ class TestPycaCapture(unittest.TestCase):
         self.event.set_data({'attach': data})
 
     def tearDown(self):
+        os.close(self.fd)
         os.remove(self.dbfile)
         shutil.rmtree(self.cadir)
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -19,10 +19,11 @@ class TestPycaDb(unittest.TestCase):
         cfg = './etc/pyca.conf'
         config.update_configuration(cfg)
 
-        _, self.dbfile = tempfile.mkstemp()
+        self.fd, self.dbfile = tempfile.mkstemp()
         config.config()['agent']['database'] = 'sqlite:///' + self.dbfile
 
     def tearDown(self):
+        os.close(self.fd)
         os.remove(self.dbfile)
 
     def test_get_session(self):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -30,7 +30,7 @@ class TestPycaIngest(unittest.TestCase):
         reload(db)
         utils.http_request = lambda x, y=False: b'xxx'
         ingest.http_request = lambda x, y=False: b'xxx'
-        _, self.dbfile = tempfile.mkstemp()
+        self.fd, self.dbfile = tempfile.mkstemp()
         self.cadir = tempfile.mkdtemp()
         config.config()['agent']['database'] = 'sqlite:///' + self.dbfile
         config.config()['capture']['directory'] = self.cadir
@@ -65,6 +65,7 @@ class TestPycaIngest(unittest.TestCase):
         self.event.set_tracks([('presenter/source', trackfile)])
 
     def tearDown(self):
+        os.close(self.fd)
         os.remove(self.dbfile)
         shutil.rmtree(self.cadir)
 

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -29,7 +29,7 @@ class TestPycaCapture(unittest.TestCase):
 
     def setUp(self):
         utils.http_request = lambda x, y=False: b'xxx'
-        _, self.dbfile = tempfile.mkstemp()
+        self.fd, self.dbfile = tempfile.mkstemp()
         config.config()['agent']['database'] = 'sqlite:///' + self.dbfile
         config.config()['service-scheduler'] = ['']
 
@@ -37,6 +37,7 @@ class TestPycaCapture(unittest.TestCase):
         db.init()
 
     def tearDown(self):
+        os.close(self.fd)
         os.remove(self.dbfile)
 
     def test_get_schedule(self):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -16,13 +16,15 @@ class TestPycaUI(unittest.TestCase):
     auth = {'Authorization': 'Basic YWRtaW46b3BlbmNhc3Q='}
 
     def setUp(self):
-        _, self.dbfile = tempfile.mkstemp()
-        _, self.previewfile = tempfile.mkstemp()
+        self.fd1, self.dbfile = tempfile.mkstemp()
+        self.fd2, self.previewfile = tempfile.mkstemp()
         config.config()['capture']['preview'] = [self.previewfile]
         config.config()['agent']['database'] = 'sqlite:///' + self.dbfile
         db.init()
 
     def tearDown(self):
+        os.close(self.fd1)
+        os.close(self.fd2)
         os.remove(self.dbfile)
         os.remove(self.previewfile)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,11 +27,12 @@ class TestPycaUtils(unittest.TestCase):
         config.config()['service-capture.admin'] = ['']
 
         # db
-        _, self.dbfile = tempfile.mkstemp()
+        self.fd, self.dbfile = tempfile.mkstemp()
         config.config()['agent']['database'] = 'sqlite:///' + self.dbfile
         db.init()
 
     def tearDown(self):
+        os.close(self.fd)
         os.remove(self.dbfile)
 
     def test_get_service(self):


### PR DESCRIPTION
The method `mkstemp` used during testing opens a file descriptor which
is never being closed again. On some systems, e.g. Windows, this causes
an exception.

In any case, the file descriptor should be caused properly. That is what
this patch does.