### PR TITLE
Mock Curl For Request

### DIFF
--- a/tests/tools.py
+++ b/tests/tools.py
@@ -22,3 +22,29 @@ def terminate_fn(num):
     global _terminate
     _terminate = num
     return __terminate
+
+
+class CurlMock():
+    CAINFO = 0
+    HTTPAUTH = 1
+    HTTPAUTH_DIGEST = 2
+    HTTPHEADER = 3
+    HTTPPOST = 4
+    HTTP_CODE = 5
+    SSL_VERIFYHOST = 6
+    SSL_VERIFYPEER = 7
+    URL = 8
+    USERPWD = 9
+    WRITEFUNCTION = 10
+
+    def setopt(self, *args):
+        pass
+
+    def perform(self):
+        pass
+
+    def getinfo(self, *args):
+        return 200
+
+    def close(self):
+        pass


### PR DESCRIPTION
This patch adds a mock version of Curl to fully test the method
`http_request()`. For everything else, `http_request()` itself is still
mocked to limit possible side-effects.