### PR TITLE
fix issue in agentstate that causes high cpu load

### DIFF
--- a/pyca/agentstate.py
+++ b/pyca/agentstate.py
@@ -25,7 +25,7 @@ def control_loop():
         update_agent_state()
 
         next_update = timestamp() + config()['agent']['update_frequency']
-        while not terminate and timestamp() < next_update:
+        while not terminate() and timestamp() < next_update:
             time.sleep(0.1)
 
     logger.info('Shutting down agentstate service')


### PR DESCRIPTION
wrong check in while loop caused constant high cpu load in the agentstate service.