### PR TITLE
Disable logging for tests

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,20 +9,22 @@ import tempfile
 import unittest
 
 from pyca import __main__, agentstate, capture, ingest, schedule, ui, utils
-from tests.tools import should_fail, ShouldFailException
-
-if sys.version_info.major > 2:
-    try:
-        from importlib import reload
-    except ImportError:
-        from imp import reload
+from tests.tools import should_fail, ShouldFailException, reload
 
 
 class TestPycaMain(unittest.TestCase):
 
+    def setUp(self):
+        # Disable `print`
+        # Ugly but compatible with Python 2
+        sys.stdout = ShouldFailException()
+        sys.stdout.write = lambda x: ''
+        sys.stdout.flush = lambda: ''
+
+    def teardown(self):
+        reload(sys)
+
     def test_help(self):
-        # shorten usage output
-        __main__.USAGE = '%s'
         # test scenarios which end in the usage being printed
         sys.argv = ['pyca', '-h']
         try:

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -3,6 +3,19 @@
 Some helper tools for pyCA testing.
 '''
 
+import logging
+
+try:
+    from importlib import reload  # noqa
+except ImportError:
+    from imp import reload  # noqa
+
+
+# Raise log level above maximum to silence logging in tests.
+# Then ensure that the log leven cannot be reset
+logging.getLogger('').setLevel(logging.CRITICAL * 100)
+logging.getLogger('').setLevel = lambda x: True
+
 
 class ShouldFailException(Exception):
     args = [None, 0]


### PR DESCRIPTION
This patch disables the logging module by increasing the log level above
CRITICAL and disabling the print function/statement to prevent the test
logs from being spammed by system log messages.