### PR TITLE
Properly reload modified bundles

### DIFF
--- a/tests/test_agentstate.py
+++ b/tests/test_agentstate.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 
 from pyca import agentstate, config, db, utils
-from tests.tools import terminate_fn
+from tests.tools import terminate_fn, reload
 
 
 class TestPycaAgentState(unittest.TestCase):
@@ -26,6 +26,7 @@ class TestPycaAgentState(unittest.TestCase):
     def tearDown(self):
         os.close(self.fd)
         os.remove(self.dbfile)
+        reload(utils)
 
     def test_run(self):
         agentstate.terminate = terminate_fn(1)
@@ -33,7 +34,3 @@ class TestPycaAgentState(unittest.TestCase):
             agentstate.run()
         except Exception:
             assert False
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -7,27 +7,16 @@ Tests for basic capturing
 import os
 import os.path
 import shutil
-import sys
 import tempfile
 import unittest
 
 from pyca import capture, config, db, utils
-from tests.tools import should_fail, terminate_fn
-
-if sys.version_info.major > 2:
-    try:
-        from importlib import reload
-    except ImportError:
-        from imp import reload
+from tests.tools import should_fail, terminate_fn, reload
 
 
 class TestPycaCapture(unittest.TestCase):
 
     def setUp(self):
-        reload(config)
-        reload(capture)
-        reload(utils)
-        reload(db)
         utils.http_request = lambda x, y=False: b'xxx'
         self.fd, self.dbfile = tempfile.mkstemp()
         self.cadir = tempfile.mkdtemp()
@@ -63,6 +52,8 @@ class TestPycaCapture(unittest.TestCase):
         os.close(self.fd)
         os.remove(self.dbfile)
         shutil.rmtree(self.cadir)
+        reload(capture)
+        reload(utils)
 
     def test_start_capture(self):
         assert capture.start_capture(self.event)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,7 +15,3 @@ class TestPycaConfig(unittest.TestCase):
         config.config()['server']['insecure'] = True
         config.config()['server']['certificate'] = 'xxx'
         config.check()
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -67,7 +67,3 @@ class TestPycaDb(unittest.TestCase):
 
         assert s.type == 0
         assert s.status == 0
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -7,27 +7,16 @@ Tests for basic capturing
 import os
 import os.path
 import shutil
-import sys
 import tempfile
 import unittest
 
 from pyca import ingest, config, db, utils
-from tests.tools import should_fail, terminate_fn
-
-if sys.version_info.major > 2:
-    try:
-        from importlib import reload
-    except ImportError:
-        from imp import reload
+from tests.tools import should_fail, terminate_fn, reload
 
 
 class TestPycaIngest(unittest.TestCase):
 
     def setUp(self):
-        reload(config)
-        reload(ingest)
-        reload(utils)
-        reload(db)
         utils.http_request = lambda x, y=False: b'xxx'
         ingest.http_request = lambda x, y=False: b'xxx'
         self.fd, self.dbfile = tempfile.mkstemp()
@@ -68,6 +57,8 @@ class TestPycaIngest(unittest.TestCase):
         os.close(self.fd)
         os.remove(self.dbfile)
         shutil.rmtree(self.cadir)
+        reload(ingest)
+        reload(utils)
 
     def test_start_ingest(self):
         assert ingest.start_ingest(self.event)
@@ -87,7 +78,3 @@ class TestPycaIngest(unittest.TestCase):
         ingest.run()
         ingest.terminate = terminate_fn(1)
         ingest.run()
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -10,7 +10,7 @@ import tempfile
 import unittest
 
 from pyca import schedule, config, db, utils
-from tests.tools import should_fail, ShouldFailException, terminate_fn
+from tests.tools import should_fail, ShouldFailException, terminate_fn, reload
 
 
 class TestPycaCapture(unittest.TestCase):
@@ -39,6 +39,8 @@ class TestPycaCapture(unittest.TestCase):
     def tearDown(self):
         os.close(self.fd)
         os.remove(self.dbfile)
+        reload(utils)
+        reload(schedule)
 
     def test_get_schedule(self):
         # Failed request
@@ -59,7 +61,3 @@ class TestPycaCapture(unittest.TestCase):
     def test_run(self):
         schedule.terminate = terminate_fn(2)
         schedule.run()
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -57,7 +57,3 @@ class TestPycaUI(unittest.TestCase):
             r = ui.serve_image(0)
             assert r.status_code == 200
             r.close()
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,21 +9,12 @@ import tempfile
 import unittest
 
 from pyca import utils, config, db
-from tests.tools import should_fail, CurlMock
-
-import sys
-if sys.version_info.major > 2:
-    try:
-        from importlib import reload
-    except ImportError:
-        from imp import reload
+from tests.tools import should_fail, CurlMock, reload
 
 
 class TestPycaUtils(unittest.TestCase):
 
     def setUp(self):
-        reload(utils)
-        reload(config)
         config.config()['service-capture.admin'] = ['']
 
         # db
@@ -34,6 +25,8 @@ class TestPycaUtils(unittest.TestCase):
     def tearDown(self):
         os.close(self.fd)
         os.remove(self.dbfile)
+        reload(utils)
+        reload(config)
 
     def test_get_service(self):
         res = '''{"services":{


### PR DESCRIPTION
To mock certain parts of the code, some tests modify modules. To ensure
these mocks are not used for testing, the modules should be re-loaded
at the end of each test and not before a test.

This pull request is based on pull request #97