### PR TITLE
Reduce Unnecessary Exception Handling

### DIFF
--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -64,11 +64,15 @@ class TestPycaCapture(unittest.TestCase):
         shutil.rmtree(self.cadir)
 
     def test_start_capture(self):
-        assert capture.start_capture(self.event)
+        capture.start_capture(self.event)
 
     def test_start_capture_recording_command_failure(self):
         config.config()['capture']['command'] = 'false'
-        assert not capture.start_capture(self.event)
+        try:
+            capture.start_capture(self.event)
+            assert False
+        except RuntimeError:
+            assert True
 
     def test_safe_start_capture(self):
         capture.start_capture = should_fail


### PR DESCRIPTION
This patch party addresses #88 by reducing the amount of try-catch
statements. `safe_start_capture` will catch exceptions anyway, hence we
need no additional exception handling in `start_capture` but can just
let it fail.