### PR TITLE
Added Capture Process Timeout

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -106,6 +106,27 @@ files            = '{{dir}}/{{name}}.webm'
 # Default:
 #preview          =
 
+# Time in seconds after an events end when a SIGTERM is sent to the capture
+# process to shut it down in case it does not do that by itself. Setting this
+# to -1 will disable the signal.
+# Type: Integer
+# Default: -1 (disabled)
+#sigterm_time     = -1
+
+# Time in seconds after an events end when a SIGKILL is sent to the capture
+# process to ensure it terminates and does not block further recordings. Note
+# that setting this lower than `sigterm_time` will set this to `sigterm_time`.
+# Setting this to -1 will disable the signal.
+# Type: Integer
+# Default: 120
+#sigkill_time     = 120
+
+# An additional exit code to 0 indicating that the capture process has
+# been completed successfully.
+# Type: integer
+# Default: 0
+#exit_code        = 0
+
 
 [server]
 
@@ -122,7 +143,7 @@ url              = 'https://octestallinone.virtuos.uos.de'
 
 # Username for the admin server (digest authentication)
 # Type: string
-# Default: matterhorn_system_account
+# Default: opencast_system_account
 username         = 'opencast_system_account'
 
 # Password for the admin server (digest authentication)

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -25,6 +25,9 @@ flavors          = force_list(default=list('presenter/source'))
 files            = force_list(default=list('{{dir}}/{{name}}.mp4'))
 preview_dir      = string(default='./recordings')
 preview          = force_list(default=list())
+sigterm_time     = integer(min=-1, default=-1)
+sigkill_time     = integer(min=-1, default=120)
+exit_code        = integer(min=0, max=255, default=0)
 
 [server]
 url              = string(default='https://octestallinone.virtuos.uos.de')

--- a/pyca/db.py
+++ b/pyca/db.py
@@ -108,6 +108,11 @@ class BaseEvent():
         '''
         return os.path.join(config()['capture']['directory'], self.name())
 
+    def remaining_duration(self, time):
+        '''Returns the remaining duration for a recording.
+        '''
+        return max(0, self.end - max(self.start, time))
+
     def status_str(self):
         '''Return status as string.
         '''

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -33,7 +33,7 @@ class TestPycaCapture(unittest.TestCase):
         self.event = db.BaseEvent()
         self.event.uid = '123123'
         self.event.start = utils.timestamp()
-        self.event.end = self.event.start + 3
+        self.event.end = self.event.start
         data = [{'data': u'äüÄÜß',
                  'fmttype': 'application/xml',
                  'x-apple-filename': 'episode.xml'},
@@ -53,6 +53,7 @@ class TestPycaCapture(unittest.TestCase):
         os.remove(self.dbfile)
         shutil.rmtree(self.cadir)
         reload(capture)
+        reload(config)
         reload(utils)
 
     def test_start_capture(self):
@@ -65,6 +66,16 @@ class TestPycaCapture(unittest.TestCase):
             assert False
         except RuntimeError:
             assert True
+
+    def test_start_capture_sigterm(self):
+        config.config()['capture']['command'] = 'sleep 10'
+        config.config()['capture']['sigterm_time'] = 0
+        capture.start_capture(self.event)
+
+    def test_start_capture_sigkill(self):
+        config.config()['capture']['command'] = 'sleep 10'
+        config.config()['capture']['sigkill_time'] = 0
+        capture.start_capture(self.event)
 
     def test_safe_start_capture(self):
         capture.start_capture = should_fail


### PR DESCRIPTION
This patch enables pyCA to terminate capture processes on its own by
sending a TERM or KILL signal to the child process. This allows pyCA to
use capture processes without time handling on their own as well as
ensuring that hanging capture processes will not lock up the whole
capture agent.

By default, no TERM signal is sent, which is the same behavior as
before. However, processes are now killed by default, two minutes after
when the capture process should have ended.

This fixes #57.