### PR TITLE
Drop Option to Ignore Timezone

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -34,12 +34,6 @@ name             = 'pyca'
 # Default: False
 #backup_mode      = False
 
-# If the capture agent should ignore timezones and assume local time. This is
-# usually not required but might help in certain circumstances.
-# Type: Boolean
-# Default: False
-#ignore_timezone  = False
-
 # Location of the database file to cache scheduled events in and keep a
 # history of recordings. This can be any database supported by SQLAlchemy.
 # Type: String

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 __CFG = '''
 [agent]
 name             = string(default='pyca')
-ignore_timezone  = boolean(default=False)
 update_frequency = integer(min=5, default=60)
 cal_lookahead    = integer(min=0, default=14)
 backup_mode      = boolean(default=false)

--- a/pyca/utils.py
+++ b/pyca/utils.py
@@ -83,6 +83,7 @@ def get_service(service_type):
 
 def unix_ts(dtval):
     '''Convert datetime into a unix timestamp.
+    This is the equivalent to Python 3's int(datetime.timestamp()).
 
     :param dt: datetime to convert
     '''
@@ -94,8 +95,6 @@ def unix_ts(dtval):
 def timestamp():
     '''Get current unix timestamp
     '''
-    if config()['agent']['ignore_timezone']:
-        return unix_ts(datetime.now())
     return unix_ts(datetime.now(tzutc()))
 
 


### PR DESCRIPTION
This Option did not work at all for a long time and would have been
breaking the compatibility to recent versions of Opencast. With
Opencast, everything is and should be converted to UTC.