### PR TITLE
Expand Configuration Validation

### DIFF
--- a/pyca/config.py
+++ b/pyca/config.py
@@ -60,6 +60,8 @@ def update_configuration(cfgfile='/etc/pyca.conf'):
     val = cfg.validate(validator)
     if val is not True:
         raise ValueError('Invalid configuration: %s' % val)
+    if len(cfg['capture']['files']) != len(cfg['capture']['flavors']):
+        raise ValueError('List of files and flavors do not match')
     globals()['__config'] = cfg
     check()
     return cfg
@@ -72,11 +74,7 @@ def check():
         logger.warning('INSECURE: HTTPS CHECKS ARE TURNED OFF. A SECURE '
                        'CONNECTION IS NOT GUARANTEED')
     if config()['server']['certificate']:
-        try:
-            with open(config()['server']['certificate'], 'rb'):
-                pass
-        except IOError as err:
-            logger.warning('Could not read certificate file: %s', err)
+        open(config()['server']['certificate'], 'rb').close()
 
 
 def config(key=None):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,5 +13,9 @@ class TestPycaConfig(unittest.TestCase):
 
     def test_check(self):
         config.config()['server']['insecure'] = True
-        config.config()['server']['certificate'] = 'xxx'
-        config.check()
+        config.config()['server']['certificate'] = '/xxx'
+        try:
+            config.check()
+            assert False
+        except IOError:
+            assert True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,17 +47,20 @@ class TestPycaMain(unittest.TestCase):
         except BaseException as e:
             assert e.code == 3
 
-    def test_broken_configuration(self):
-        fd, fn = tempfile.mkstemp()
-        with open(fn, 'w') as f:
-            f.write('[agent]\nupdate_frequency = "qwe"')
-        sys.argv = ['pyca', '-c', fn, 'fail']
-        try:
-            __main__.main()
-        except BaseException as e:
-            assert e.code == 4
-        os.close(fd)
-        os.remove(fn)
+    def test_broken_configuration_type(self):
+        configs = ('[capture]\nflavors = "x/source"\nfiles = a, b',
+                   '[agent]\nupdate_frequency = "nan"')
+        for config in configs:
+            fd, fn = tempfile.mkstemp()
+            with open(fn, 'w') as f:
+                f.write(config)
+            sys.argv = ['pyca', '-c', fn, 'fail']
+            try:
+                __main__.main()
+            except BaseException as e:
+                assert e.code == 4
+            os.close(fd)
+            os.remove(fn)
 
     def test_run(self):
         for mod in (agentstate, capture, ingest, schedule):


### PR DESCRIPTION
This patch adds more configuration validation which now ensures that the
lists for files and flavors are of equal length since that would cause
errors later anyway. Best to fail early and let the user know about the
problem.

This is a further improvement of #86