### PR TITLE
Remove Unnecessary Return Value

### DIFF
--- a/pyca/capture.py
+++ b/pyca/capture.py
@@ -78,7 +78,6 @@ def safe_start_capture(event):
     '''
     try:
         start_capture(event)
-        return True
     except Exception:
         logger.error('Recording failed')
         logger.error(traceback.format_exc())
@@ -86,7 +85,6 @@ def safe_start_capture(event):
         recording_state(event.uid, 'capture_error')
         update_event_status(event, Status.FAILED_RECORDING)
         set_service_status_immediate(Service.CAPTURE, ServiceStatus.IDLE)
-        return False
 
 
 def recording_command(directory, name, duration):

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -67,10 +67,11 @@ class TestPycaCapture(unittest.TestCase):
             assert True
 
     def test_safe_start_capture(self):
+        '''Ensure that safe_start_capture always returns without error to not
+        disrupt the main loop.
+        '''
         capture.start_capture = should_fail
-        assert not capture.safe_start_capture(self.event)
-        capture.start_capture = lambda x: True
-        assert capture.safe_start_capture(self.event)
+        capture.safe_start_capture(self.event)
 
     def test_run(self):
         capture.terminate = terminate_fn(1)


### PR DESCRIPTION
This patch removes the return value of `safe_start_capture` since its
sole purpose is to catch all errors to ensure the mail loop is not
disrupted which means that no return values are expected and evaluated
anyway.