### PR TITLE
Logging Configuration and Initialization

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -179,7 +179,8 @@ password         = 'CHANGE_ME'
 
 [logging]
 
-# Log to the system logger
+# Log to the system logger. Note that this will use /dev/log which may not be
+# available on non Linux systems.
 # Type: boolean
 # Default: False
 #syslog           = False
@@ -190,6 +191,10 @@ password         = 'CHANGE_ME'
 #stderr           = True
 
 # Configure the log level
-# possible values are: debug, info, warning and error
+# Possible values are: debug, info, warning and error
 # Default: info
 #level            = info
+
+# Log format configuration
+# Default: [%(name)s:%(lineno)s:%(funcName)s()] [%(levelname)s] %(message)s
+#format           = [%(name)s:%(lineno)s:%(funcName)s()] [%(levelname)s] %(message)s

--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -8,8 +8,6 @@
 '''
 
 import getopt
-import logging
-import logging.handlers
 import multiprocessing
 import os
 import signal
@@ -99,24 +97,6 @@ def main():
     except ValueError as e:
         print(str(e))
         sys.exit(4)
-
-    # Initialize logger
-    handlers = []
-    logconf = config.config()['logging']
-    if logconf['syslog']:
-        handlers.append(logging.handlers.SysLogHandler(address='/dev/log'))
-    if logconf['stderr']:
-        handlers.append(logging.StreamHandler(sys.stderr))
-    logger = logging.getLogger('')
-    for h in handlers:
-        h.setFormatter(logging.Formatter(
-            '[%(name)s:%(lineno)s:%(funcName)s()] %(message)s'))
-        logger.addHandler(h)
-
-    logger.setLevel(logconf['level'].upper())
-
-    logger.info('Configuration loaded from %s' % cfg)
-    logger.info('Log level set to %s' % logconf['level'])
 
     # Set signal handler
     signal.signal(signal.SIGINT, sigint_handler)


### PR DESCRIPTION
This patch will initialize the logger as soon as the configuration is
loaded to be able to log several configuration and logging settings
users should know about (e.g. curl --insecure option).

This patch also enables users to configure the format of the log
messages.

This fixes #110
This fixes #19