### PR TITLE
Remove Duplicated Code From Ingest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
    - "3.6"
 
 before_install:
-   - pip install flake8 python-coveralls coverage
+   - pip install flake8 python-coveralls mock coverage
 
 script:
    - coverage run --source=pyca --omit='*.html' -m unittest discover -s tests

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -10,71 +10,74 @@ import shutil
 import tempfile
 import unittest
 
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
 from pyca import ingest, config, db, utils
-from tests.tools import should_fail, terminate_fn, reload
+from tests.tools import should_fail, terminate_fn
 
 
 class TestPycaIngest(unittest.TestCase):
 
     def setUp(self):
-        utils.http_request = lambda x, y=False: b'xxx'
         ingest.http_request = lambda x, y=False: b'xxx'
         self.fd, self.dbfile = tempfile.mkstemp()
         self.cadir = tempfile.mkdtemp()
-        config.config()['agent']['database'] = 'sqlite:///' + self.dbfile
-        config.config()['capture']['directory'] = self.cadir
+        config.config('agent')['database'] = 'sqlite:///' + self.dbfile
+        config.config('capture')['directory'] = self.cadir
         config.config()['service-ingest'] = ['']
         config.config()['service-capture.admin'] = ['']
 
         # Mock event
         db.init()
-        self.event = db.RecordedEvent()
-        self.event.uid = '123123'
-        self.event.start = utils.timestamp()
-        self.event.end = self.event.start + 1
-        data = [{'data': u'äüÄÜß',
+        event = db.RecordedEvent()
+        event.uid = '123123'
+        event.status = db.Status.FINISHED_RECORDING
+        event.start = utils.timestamp()
+        event.end = event.start + 1
+        prop = 'org.opencastproject.capture.agent.properties'
+        dcns = 'http://www.opencastproject.org/xsd/1.0/dublincore/'
+        data = [{'data': u'äü%sÄÜß' % dcns,
                  'fmttype': 'application/xml',
                  'x-apple-filename': 'episode.xml'},
-                {'data': u'äüÄÜß',
+                {'data': u'äü%sÄÜß' % dcns,
                  'fmttype': 'application/xml',
                  'x-apple-filename': 'series.xml'},
                 {'data': u'event.title=äüÄÜß\n' +
                          u'org.opencastproject.workflow.config.x=123\n' +
                          u'org.opencastproject.workflow.definition=fast',
                  'fmttype': 'application/text',
-                 'x-apple-filename': 'org.opencastproject.capture.agent' +
-                                     '.properties'}]
-        self.event.set_data({'attach': data})
+                 'x-apple-filename': prop}]
+        event.set_data({'attach': data})
 
         # Create recording
-        os.mkdir(self.event.directory())
-        trackfile = os.path.join(self.event.directory(), 'test.mp4')
-        with open(trackfile, 'wb') as f:
-            f.write(b'123')
-        self.event.set_tracks([('presenter/source', trackfile)])
+        os.mkdir(event.directory())
+        trackfile = os.path.join(event.directory(), 'test.mp4')
+        open(trackfile, 'wb').close()
+        event.set_tracks([('presenter/source', trackfile)])
+        session = db.get_session()
+        session.add(event)
+        session.commit()
+        self.event = db.RecordedEvent(event)
 
     def tearDown(self):
         os.close(self.fd)
         os.remove(self.dbfile)
         shutil.rmtree(self.cadir)
-        reload(ingest)
-        reload(utils)
 
-    def test_start_ingest(self):
-        assert ingest.start_ingest(self.event)
-
-    def test_start_ingest_failure(self):
-        ingest.ingest = should_fail
-        assert not ingest.start_ingest(self.event)
-
-    def test_safe_start_ingest(self):
-        ingest.start_ingest = should_fail
-        assert not ingest.safe_start_ingest(1)
-        ingest.start_ingest = lambda x: True
-        assert ingest.safe_start_ingest(1)
+    @patch(__name__+'.ingest.ingest')
+    def test_safe_start_ingest(self, ingest_fn):
+        ingest_fn.side_effect = lambda x: None
+        ingest.safe_start_ingest(self.event)
+        ingest_fn.side_effect = should_fail
+        ingest.safe_start_ingest(self.event)
 
     def test_run(self):
         ingest.terminate(True)
         ingest.run()
         ingest.terminate = terminate_fn(1)
+        ingest.run()
+        config.config('agent')['backup_mode'] = True
         ingest.run()


### PR DESCRIPTION
This patch cleans up the ingest module, removing unnecessary code left
over from previous versions and simplifying the module's structure.