### PR TITLE
Automatically Refresh User Interface

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -126,7 +126,7 @@ command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -f lavfi -i si
 
 # URL of the admin server.
 # Type: string
-# Default: http://octestallinone.virtuos.uos.de:8080
+# Default: https://octestallinone.virtuos.uos.de
 url              = 'https://octestallinone.virtuos.uos.de'
 
 # Analogue of -k, --insecure option in curl. Allows insercure SSL connections
@@ -167,8 +167,8 @@ password         = 'CHANGE_ME'
 
 # How often (seconds) should the web interface refresh itself.
 # Type: integer
-# Default: 2
-#refresh_rate     = 2
+# Default: 10
+#refresh_rate     = 10
 
 # URL where the web interface is reachable. This will be sent to the Matterhorn
 # core and displayed in the admin interface.

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -40,7 +40,7 @@ certificate      = string(default='')
 [ui]
 username         = string(default='admin')
 password         = string(default='opencast')
-refresh_rate     = integer(min=1, default=2)
+refresh_rate     = integer(min=1, default=10)
 url              = string(default='http://localhost:5000')
 
 [logging]

--- a/pyca/ui/templates/layout.html
+++ b/pyca/ui/templates/layout.html
@@ -4,6 +4,9 @@
     <meta http-equiv=content-type content="text/html; charset=utf-8" />
     <meta name=viewport content="width=device-width, initial-scale=1">
 
+    <!-- Should be removed once we can load data through the API -->
+    <meta http-equiv="refresh" content="{{ config['ui']['refresh_rate'] }}">
+
     <script src="{{ url_for('static', filename='jquery.min.js') }}"></script>
     <script src="{{ url_for('static', filename='func.js') }}"></script>
     <title>pyCA</title>


### PR DESCRIPTION
This patch re-enables the automatic refreshing of the user interface.
The HTML meta-refresh functionality is used for this until the API is
finished and we can avoid a reload of the whole user interface.