### PR TITLE
Fix DC Catalog Encoding

### DIFF
--- a/pyca/ingest.py
+++ b/pyca/ingest.py
@@ -71,7 +71,7 @@ def ingest(event):
             logger.info('Adding %s DC catalog' % name)
             fields = [('mediaPackage', mediapackage),
                       ('flavor', 'dublincore/%s' % name),
-                      ('dublinCore', data)]
+                      ('dublinCore', data.encode('utf-8'))]
             mediapackage = http_request(service + '/addDCCatalog', fields)
 
     # add track


### PR DESCRIPTION
This patch fixes the UTF-8 encoding of dublin core catalogs causing the
ingest to fail in case special characters were contained in the
catalogs.

Fixes #114