### PR TITLE
add simple Makefile for lint and test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_install:
    - pip install flake8 python-coveralls mock coverage
 
 script:
-   - coverage run --source=pyca --omit='*.html' -m unittest discover -s tests
-   - flake8 $(find . -name '*.py')
+   - make test
+   - make lint
 
 after_success:
    - coveralls

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: lint test
 
 lint:
-	@flake8 $(find . -name '*.py')
+	@flake8 $$(find . -name '*.py')
 
 test:
 	@coverage run --source=pyca --omit='*.html' -m unittest discover -s tests

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+all: lint test
+
+lint:
+	@flake8 $(find . -name '*.py')
+
+test:
+	@coverage run --source=pyca --omit='*.html' -m unittest discover -s tests


### PR DESCRIPTION
This patch adds a simple Makefile that runs flake8 and coveralls. Developers can then simply run `make` to do the same tests that are used in TravisCI without manually copying the commands from `.travisci.yml`.