### PR TITLE
Store Title In Database

### DIFF
--- a/pyca/db.py
+++ b/pyca/db.py
@@ -11,7 +11,7 @@ import os.path
 import string
 from pyca.config import config
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, String, LargeBinary, create_engine
+from sqlalchemy import Column, Integer, Text, LargeBinary, create_engine
 from sqlalchemy.orm import sessionmaker
 Base = declarative_base()
 
@@ -82,9 +82,10 @@ class BaseEvent():
 
     __tablename__ = 'event'
 
-    uid = Column('uid', String(255), nullable=False, primary_key=True)
+    uid = Column('uid', Text(), nullable=False, primary_key=True)
     start = Column('start', Integer(), primary_key=True)
     end = Column('end', Integer(), nullable=False)
+    title = Column('title', Text())
     data = Column('data', LargeBinary(), nullable=False)
 
     def get_data(self):
@@ -134,6 +135,7 @@ class BaseEvent():
         return {'start': self.start,
                 'end': self.end,
                 'uid': self.uid,
+                'title': self.title,
                 'data': self.data}
 
 
@@ -157,6 +159,7 @@ class RecordedEvent(Base, BaseEvent):
             self.uid = event.uid
             self.start = event.start
             self.end = event.end
+            self.title = event.title
             self.data = event.data
             if hasattr(event, 'status'):
                 self.status = event.status

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -85,6 +85,7 @@ def get_schedule():
         e.start = event['dtstart']
         e.end = event['dtend']
         e.uid = event.get('uid')
+        e.title = event.get('summary')
         e.set_data(event)
         db.add(e)
     db.commit()

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -32,6 +32,7 @@ class TestPycaCapture(unittest.TestCase):
         db.init()
         self.event = db.BaseEvent()
         self.event.uid = '123123'
+        self.event.title = u'äüÄÜß'
         self.event.start = utils.timestamp()
         self.event.end = self.event.start
         data = [{'data': u'äüÄÜß',

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -20,6 +20,7 @@ class TestPycaCapture(unittest.TestCase):
     VCAL = ('''BEGIN:VCALENDAR
         BEGIN:VEVENT
         UID:20170223T171244Z
+        SUMMARY:TEST
         DTSTART:20170223T230000Z
         DTEND:%sZ
         ATTACH;FMTTYPE=application/xml;VALUE=BINARY;ENCODING=BASE64;


### PR DESCRIPTION
This patch will store the title of recordings in the database so it can
later be used in the user interface.