### PR TITLE
Strip / from end of base url

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -124,7 +124,8 @@ command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -f lavfi -i si
 
 [server]
 
-# URL of the admin server.
+# Base URL of the admin server. This corresponds to the
+# org.opencastproject.server.url setting of Opencast.
 # Type: string
 # Default: https://octestallinone.virtuos.uos.de
 url              = 'https://octestallinone.virtuos.uos.de'

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -86,6 +86,11 @@ def update_configuration(cfgfile=None):
         raise ValueError('List of files and flavors do not match')
     globals()['__config'] = cfg
     logger_init()
+    if cfg['server'].get('url','').endswith('/'):
+        logger.warning('Stripping / from the end of the base url. This seems '
+                'like a configuration error. If you want to keep it, use // '
+                'at the end of the configuration value.')
+        cfg['server']['url'] = cfg['server']['url'][:-1]
     logger.info('Configuration loaded from %s' % cfgfile)
     check()
     return cfg


### PR DESCRIPTION
This patch removes one `/` from the end of the configured base URL in
pyCA since it is very likely a configuration issue. PyCA warns warns
about the user about this action so he can properly fix the
configuration or, in the unlikely case that the URL really should end
with `/`, intervene and add a second `/` to the configured value.

This fixes #132