### PR TITLE
Warn About Trailing Slash In URL

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -124,7 +124,8 @@ command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -f lavfi -i si
 
 [server]
 
-# URL of the admin server.
+# Base URL of the admin server. This corresponds to the
+# org.opencastproject.server.url setting of Opencast.
 # Type: string
 # Default: https://octestallinone.virtuos.uos.de
 url              = 'https://octestallinone.virtuos.uos.de'

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -86,6 +86,10 @@ def update_configuration(cfgfile=None):
         raise ValueError('List of files and flavors do not match')
     globals()['__config'] = cfg
     logger_init()
+    if cfg['server'].get('url', '').endswith('/'):
+        logger.warning('Base URL ends with /. This is most likely a '
+                       'configuration error. The URL should contain nothing '
+                       'of the service paths.')
     logger.info('Configuration loaded from %s' % cfgfile)
     check()
     return cfg


### PR DESCRIPTION
This patch adds a warning if the base URL configuration value ends with
a `/`. That configuration should contain nothing of the services paths.
Hence, a trailing slash is very likely a configuration issue which needs
to be addressed by the user.

This fixes #132