### PR TITLE
Fix Serving Preview Images

### DIFF
--- a/pyca/ui/__init__.py
+++ b/pyca/ui/__init__.py
@@ -76,19 +76,19 @@ def home():
                            dtfmt=dtfmt)
 
 
-@app.route("/img/<int:img>")
+@app.route("/img/<int:image_id>")
 @requires_auth
 def serve_image(image_id):
     '''Serve the preview image with the given id
     '''
-    filepath = ''
     try:
         preview_dir = config()['capture']['preview_dir']
         filepath = config()['capture']['preview'][image_id]
         filepath = filepath.replace('{{previewdir}}', preview_dir)
+        filepath = os.path.abspath(filepath)
         if os.path.isfile(filepath):
-            [directory, filename] = filepath.rsplit('/', 1)
+            directory, filename = filepath.rsplit('/', 1)
             return send_from_directory(directory, filename)
-    except:
+    except (IndexError, KeyError):
         pass
     return '', 404

--- a/pyca/ui/static/style.css
+++ b/pyca/ui/static/style.css
@@ -103,3 +103,8 @@ tr.extendlist td {
     padding: 5px 10px;
     text-align: center;
 }
+
+#preview img {
+    max-width: 90%;
+    max-height: 300px;
+}

--- a/pyca/ui/templates/home.html
+++ b/pyca/ui/templates/home.html
@@ -33,10 +33,10 @@
 </summary>
 
 <main class=center>
-<section>
+<section id=preview>
     <h2>Preview Images</h2>
     {% for p in preview %}
-        <img style="max-width: 90%;" src="/img/{{ p }}" />
+        <img src="/img/{{ p }}" />
     {% else %}
         No preview image
     {% endfor %}

--- a/readme.rst
+++ b/readme.rst
@@ -109,6 +109,25 @@ regular capture agent fails to record (for whatever reasons). Just match the
 name of the pyCA to that of the regular capture agent.
 
 
+Preview
+*******
+
+The web interface can show preview images for running capture processes. To
+enable this, the capture process must generate these still images and write
+them to a pre-defined location. An simple example configuration using FFmpeg
+could look like this::
+
+    command          = '''ffmpeg -nostats -re
+                          -f lavfi -r 25 -i testsrc
+                          -f lavfi -i sine -t {{time}}
+                          -map 0:v -map 1:a {{dir}}/{{name}}.webm
+                          -map 0:v -r 1 -updatefirst 1 {{previewdir}}/preview.jpg'''
+
+    preview = '{{previewdir}}/preview.jpg'
+
+This command will record audio and video from a test source and write a WebM
+file while simultaneously updating a still image every second.
+
 .. _Opencast: http://opencast.org
 .. _GNU Lesser General Public License: https://raw.githubusercontent.com/opencast/pyCA/master/license.lgpl
 .. _Raspberry Pi: http://www.raspberrypi.org


### PR DESCRIPTION
commit df99d1c3778a1b333415879235f475c8c8d4c215
Author: Lars Kiesow <lkiesow@uos.de>
Date:   Sat Jun 3 18:24:18 2017 +0200

    Add Documentation About Preview Images
    
    This patch adds some documentation about how to generate and configure
    preview images which are displayed in the web interface to monitor
    running capture processes.
    
    This is related to #131

commit 8c06480d69028572247e72fd92d872fcc2540bf7
Author: Lars Kiesow <lkiesow@uos.de>
Date:   Sat Jun 3 18:21:16 2017 +0200

    Fix Serving Preview Images
    
    This patch fixes #131 (preview images not working), ensuring that they
    image files are served from relative paths as well. It also updates the
    web interface to limit the maximum display size of preview images.
