### PR TITLE
Fix Log Message Typo

### DIFF
--- a/pyca/config.py
+++ b/pyca/config.py
@@ -105,7 +105,7 @@ def check():
         # Ensure certificate exists and is readable
         open(config('server')['certificate'], 'rb').close()
     if config('agent')['backup_mode']:
-        logger.info('Agent runs in bakup mode. No data will be sent to '
+        logger.info('Agent runs in backup mode. No data will be sent to '
                     'Opencast')
 
 


### PR DESCRIPTION
This patch fixes a typo in the backup mode log message.

Fixes #138