### PR TITLE
Use New Test Server

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -127,8 +127,8 @@ command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -f lavfi -i si
 # Base URL of the admin server. This corresponds to the
 # org.opencastproject.server.url setting of Opencast.
 # Type: string
-# Default: https://octestallinone.virtuos.uos.de
-url              = 'https://octestallinone.virtuos.uos.de'
+# Default: https://develop.opencast.org
+url              = 'https://develop.opencast.org'
 
 # Analogue of -k, --insecure option in curl. Allows insercure SSL connections
 # while using HTTPS on the server.

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -32,7 +32,7 @@ sigkill_time     = integer(min=-1, default=120)
 exit_code        = integer(min=0, max=255, default=0)
 
 [server]
-url              = string(default='https://octestallinone.virtuos.uos.de')
+url              = string(default='https://develop.opencast.org')
 username         = string(default='opencast_system_account')
 password         = string(default='CHANGE_ME')
 insecure         = boolean(default=False)


### PR DESCRIPTION
This patch changes the default configuration to use the new Opencast
test server following Opencast's develop branch.