### PR TITLE
Handle non-URL characters in capture agent name

### DIFF
--- a/pyca/config.py
+++ b/pyca/config.py
@@ -77,7 +77,7 @@ def update_configuration(cfgfile=None):
     '''
     configobj.DEFAULT_INTERPOLATION = 'template'
     cfgfile = configuration_file(cfgfile)
-    cfg = configobj.ConfigObj(cfgfile, configspec=cfgspec)
+    cfg = configobj.ConfigObj(cfgfile, configspec=cfgspec, encoding='utf-8')
     validator = Validator()
     val = cfg.validate(validator)
     if val is not True:

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -16,8 +16,13 @@ from datetime import datetime
 import dateutil.parser
 import logging
 import pycurl
+import sys
 import time
 import traceback
+if sys.version_info[0] == 2:
+    from urllib import urlencode
+else:
+    from urllib.parse import urlencode
 
 logger = logging.getLogger(__name__)
 
@@ -58,11 +63,12 @@ def get_schedule():
     '''Try to load schedule from the Matterhorn core. Returns a valid schedule
     or None on failure.
     '''
-    uri = '%s/calendars?agentid=%s' % (config()['service-scheduler'][0],
-                                       config()['agent']['name'])
+    params = {'agentid': config()['agent']['name'].encode('utf8')}
     lookahead = config()['agent']['cal_lookahead'] * 24 * 60 * 60
     if lookahead:
-        uri += '&cutoff=%i' % ((timestamp() + lookahead) * 1000)
+        params['cutoff'] = str((timestamp() + lookahead) * 1000)
+    uri = '%s/calendars?%s' % (config()['service-scheduler'][0],
+                               urlencode(params))
     try:
         vcal = http_request(uri)
     except pycurl.error as e:

--- a/pyca/utils.py
+++ b/pyca/utils.py
@@ -21,8 +21,10 @@ import sys
 import time
 if sys.version_info[0] == 2:
     from cStringIO import StringIO as bio
+    from urllib import quote as urlquote
 else:
     from io import BytesIO as bio
+    from urllib.parse import quote as urlquote
 
 
 logger = logging.getLogger(__name__)
@@ -137,8 +139,8 @@ def register_ca(status='idle'):
     if config()['agent']['backup_mode']:
         return
     params = [('address', config()['ui']['url']), ('state', status)]
-    url = '%s/agents/%s' % (config()['service-capture.admin'][0],
-                            config()['agent']['name'])
+    name = urlquote(config()['agent']['name'].encode('utf-8'), safe='')
+    url = '%s/agents/%s' % (config()['service-capture.admin'][0], name)
     try:
         response = http_request(url, params).decode('utf-8')
         if response:


### PR DESCRIPTION
Since the capture agent name is used as part of request URLs (both as
path parameter and as query string), it needs to be URL encoded for
these requests.

This patch also ensures that Unicode characters used in the agents name
work as expected.

This fixes #146