### PR TITLE
add regular systemd notification for watchdog

### DIFF
--- a/pyca/agentstate.py
+++ b/pyca/agentstate.py
@@ -16,17 +16,17 @@ import sdnotify
 import time
 
 logger = logging.getLogger(__name__)
-n = sdnotify.SystemdNotifier()
+notify = sdnotify.SystemdNotifier()
 
 
 def control_loop():
     '''Main loop, updating the capture agent state.
     '''
     set_service_status(Service.AGENTSTATE, ServiceStatus.BUSY)
-    n.notify('READY=1')
-    n.notify('STATUS=Running')
+    notify.notify('READY=1')
+    notify.notify('STATUS=Running')
     while not terminate():
-        n.notify('WATCHDOG=1')
+        notify.notify('WATCHDOG=1')
         update_agent_state()
 
         next_update = timestamp() + config()['agent']['update_frequency']

--- a/pyca/agentstate.py
+++ b/pyca/agentstate.py
@@ -23,9 +23,10 @@ def control_loop():
     '''Main loop, updating the capture agent state.
     '''
     set_service_status(Service.AGENTSTATE, ServiceStatus.BUSY)
-    n.notify("READY=1")
+    n.notify('READY=1')
+    n.notify('STATUS=Running')
     while not terminate():
-        n.notify('STATUS=Running')
+        n.notify('WATCHDOG=1')
         update_agent_state()
 
         next_update = timestamp() + config()['agent']['update_frequency']

--- a/pyca/agentstate.py
+++ b/pyca/agentstate.py
@@ -12,16 +12,20 @@ from pyca.utils import terminate
 from pyca.config import config
 from pyca.db import Service, ServiceStatus
 import logging
+import sdnotify
 import time
 
 logger = logging.getLogger(__name__)
+n = sdnotify.SystemdNotifier()
 
 
 def control_loop():
     '''Main loop, updating the capture agent state.
     '''
     set_service_status(Service.AGENTSTATE, ServiceStatus.BUSY)
+    n.notify("READY=1")
     while not terminate():
+        n.notify('STATUS=Running')
         update_agent_state()
 
         next_update = timestamp() + config()['agent']['update_frequency']

--- a/pyca/capture.py
+++ b/pyca/capture.py
@@ -25,7 +25,7 @@ import time
 import traceback
 
 logger = logging.getLogger(__name__)
-n = sdnotify.SystemdNotifier()
+notify = sdnotify.SystemdNotifier()
 captureproc = None
 
 
@@ -118,11 +118,11 @@ def recording_command(event):
     hasattr(subprocess, 'DEVNULL') or os.close(DEVNULL)
 
     # Set systemd status
-    n.notify('STATUS=Capturing')
+    notify.notify('STATUS=Capturing')
 
     # Check process
     while captureproc.poll() is None:
-        n.notify('WATCHDOG=1')
+        notify.notify('WATCHDOG=1')
         if sigcustom_time and timestamp() > sigcustom_time:
             logger.info("Sending custom signal to capture process")
             captureproc.send_signal(conf['sigcustom'])
@@ -151,7 +151,7 @@ def recording_command(event):
         raise RuntimeError('Recording failed (%i)' % captureproc.returncode)
 
     # Reset systemd status
-    n.notify('STATUS=Waiting')
+    notify.notify('STATUS=Waiting')
 
     # Return [(flavor,path),…]
     files = (f.replace('{{dir}}', event.directory()) for f in conf['files'])
@@ -164,10 +164,10 @@ def control_loop():
     well as starting the capture process if necessry.
     '''
     set_service_status(Service.CAPTURE, ServiceStatus.IDLE)
-    n.notify('READY=1')
-    n.notify('STATUS=Waiting')
+    notify.notify('READY=1')
+    notify.notify('STATUS=Waiting')
     while not terminate():
-        n.notify('WATCHDOG=1')
+        notify.notify('WATCHDOG=1')
         # Get next recording
         event = get_session().query(UpcomingEvent)\
                              .filter(UpcomingEvent.start <= timestamp())\

--- a/pyca/capture.py
+++ b/pyca/capture.py
@@ -117,9 +117,12 @@ def recording_command(event):
     captureproc = subprocess.Popen(args, stdin=DEVNULL)
     hasattr(subprocess, 'DEVNULL') or os.close(DEVNULL)
 
+    # Set systemd status
+    n.notify('STATUS=Capturing')
+
     # Check process
     while captureproc.poll() is None:
-        n.notify('STATUS=Capturing')
+        n.notify('WATCHDOG=1')
         if sigcustom_time and timestamp() > sigcustom_time:
             logger.info("Sending custom signal to capture process")
             captureproc.send_signal(conf['sigcustom'])
@@ -147,6 +150,9 @@ def recording_command(event):
     if captureproc.poll() > 0 and captureproc.returncode != exitcode:
         raise RuntimeError('Recording failed (%i)' % captureproc.returncode)
 
+    # Reset systemd status
+    n.notify('STATUS=Waiting')
+
     # Return [(flavor,path),…]
     files = (f.replace('{{dir}}', event.directory()) for f in conf['files'])
     files = (f.replace('{{name}}', event.name()) for f in files)
@@ -158,9 +164,10 @@ def control_loop():
     well as starting the capture process if necessry.
     '''
     set_service_status(Service.CAPTURE, ServiceStatus.IDLE)
-    n.notify("READY=1")
+    n.notify('READY=1')
+    n.notify('STATUS=Waiting')
     while not terminate():
-        n.notify('STATUS=Waiting')
+        n.notify('WATCHDOG=1')
         # Get next recording
         event = get_session().query(UpcomingEvent)\
                              .filter(UpcomingEvent.start <= timestamp())\

--- a/pyca/ingest.py
+++ b/pyca/ingest.py
@@ -20,7 +20,7 @@ import time
 import traceback
 
 logger = logging.getLogger(__name__)
-n = sdnotify.SystemdNotifier()
+notify = sdnotify.SystemdNotifier()
 
 
 def get_config_params(properties):
@@ -44,7 +44,7 @@ def ingest(event):
     '''
     # Update status
     set_service_status(Service.INGEST, ServiceStatus.BUSY)
-    n.notify('STATUS=Uploading')
+    notify.notify('STATUS=Uploading')
     recording_state(event.uid, 'uploading')
     update_event_status(event, Status.UPLOADING)
 
@@ -99,7 +99,7 @@ def ingest(event):
     # Update status
     recording_state(event.uid, 'upload_finished')
     update_event_status(event, Status.FINISHED_UPLOADING)
-    n.notify('STATUS=Running')
+    notify.notify('STATUS=Running')
     set_service_status_immediate(Service.INGEST, ServiceStatus.IDLE)
 
     logger.info('Finished ingest')
@@ -125,10 +125,10 @@ def control_loop():
     well as starting the capture process if necessry.
     '''
     set_service_status(Service.INGEST, ServiceStatus.IDLE)
-    n.notify('READY=1')
-    n.notify('STATUS=Running')
+    notify.notify('READY=1')
+    notify.notify('STATUS=Running')
     while not terminate():
-        n.notify('WATCHDOG=1')
+        notify.notify('WATCHDOG=1')
         # Get next recording
         event = get_session().query(RecordedEvent)\
                              .filter(RecordedEvent.status ==

--- a/pyca/ingest.py
+++ b/pyca/ingest.py
@@ -15,10 +15,12 @@ from pyca.utils import update_event_status, terminate
 from random import randrange
 import logging
 import pycurl
+import sdnotify
 import time
 import traceback
 
 logger = logging.getLogger(__name__)
+n = sdnotify.SystemdNotifier()
 
 
 def get_config_params(properties):
@@ -121,8 +123,10 @@ def control_loop():
     well as starting the capture process if necessry.
     '''
     set_service_status(Service.INGEST, ServiceStatus.IDLE)
+    n.notify("READY=1")
     while not terminate():
         # Get next recording
+        n.notify('STATUS=Running')
         event = get_session().query(RecordedEvent)\
                              .filter(RecordedEvent.status ==
                                      Status.FINISHED_RECORDING).first()

--- a/pyca/ingest.py
+++ b/pyca/ingest.py
@@ -44,6 +44,7 @@ def ingest(event):
     '''
     # Update status
     set_service_status(Service.INGEST, ServiceStatus.BUSY)
+    n.notify('STATUS=Uploading')
     recording_state(event.uid, 'uploading')
     update_event_status(event, Status.UPLOADING)
 
@@ -98,6 +99,7 @@ def ingest(event):
     # Update status
     recording_state(event.uid, 'upload_finished')
     update_event_status(event, Status.FINISHED_UPLOADING)
+    n.notify('STATUS=Running')
     set_service_status_immediate(Service.INGEST, ServiceStatus.IDLE)
 
     logger.info('Finished ingest')
@@ -123,10 +125,11 @@ def control_loop():
     well as starting the capture process if necessry.
     '''
     set_service_status(Service.INGEST, ServiceStatus.IDLE)
-    n.notify("READY=1")
+    n.notify('READY=1')
+    n.notify('STATUS=Running')
     while not terminate():
+        n.notify('WATCHDOG=1')
         # Get next recording
-        n.notify('STATUS=Running')
         event = get_session().query(RecordedEvent)\
                              .filter(RecordedEvent.status ==
                                      Status.FINISHED_RECORDING).first()

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -26,7 +26,7 @@ else:
     from urllib.parse import urlencode
 
 logger = logging.getLogger(__name__)
-n = sdnotify.SystemdNotifier()
+notify = sdnotify.SystemdNotifier()
 
 
 def parse_ical(vcal):
@@ -103,9 +103,9 @@ def control_loop():
     '''Main loop, retrieving the schedule.
     '''
     set_service_status(Service.SCHEDULE, ServiceStatus.BUSY)
-    n.notify('READY=1')
+    notify.notify('READY=1')
     while not terminate():
-        n.notify('WATCHDOG=1')
+        notify.notify('WATCHDOG=1')
         # Try getting an updated schedule
         get_schedule()
         session = get_session()
@@ -116,11 +116,11 @@ def control_loop():
         if next_event:
             logger.info('Next scheduled recording: %s',
                         datetime.fromtimestamp(next_event.start))
-            n.notify('STATUS=Next scheduled recording: %s' %
+            notify.notify('STATUS=Next scheduled recording: %s' %
                      datetime.fromtimestamp(next_event.start))
         else:
             logger.info('No scheduled recording')
-            n.notify('STATUS=No scheduled recording')
+            notify.notify('STATUS=No scheduled recording')
         session.close()
 
         next_update = timestamp() + config()['agent']['update_frequency']

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -103,8 +103,9 @@ def control_loop():
     '''Main loop, retrieving the schedule.
     '''
     set_service_status(Service.SCHEDULE, ServiceStatus.BUSY)
-    n.notify("READY=1")
+    n.notify('READY=1')
     while not terminate():
+        n.notify('WATCHDOG=1')
         # Try getting an updated schedule
         get_schedule()
         session = get_session()

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -115,7 +115,8 @@ def control_loop():
         if next_event:
             logger.info('Next scheduled recording: %s',
                         datetime.fromtimestamp(next_event.start))
-            n.notify('STATUS=Next scheduled recording: %s' % datetime.fromtimestamp(next_event.start))
+            n.notify('STATUS=Next scheduled recording: %s' %
+                     datetime.fromtimestamp(next_event.start))
         else:
             logger.info('No scheduled recording')
             n.notify('STATUS=No scheduled recording')

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -117,7 +117,7 @@ def control_loop():
             logger.info('Next scheduled recording: %s',
                         datetime.fromtimestamp(next_event.start))
             notify.notify('STATUS=Next scheduled recording: %s' %
-                     datetime.fromtimestamp(next_event.start))
+                          datetime.fromtimestamp(next_event.start))
         else:
             logger.info('No scheduled recording')
             notify.notify('STATUS=No scheduled recording')

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -16,6 +16,7 @@ from datetime import datetime
 import dateutil.parser
 import logging
 import pycurl
+import sdnotify
 import sys
 import time
 import traceback
@@ -25,6 +26,7 @@ else:
     from urllib.parse import urlencode
 
 logger = logging.getLogger(__name__)
+n = sdnotify.SystemdNotifier()
 
 
 def parse_ical(vcal):
@@ -101,6 +103,7 @@ def control_loop():
     '''Main loop, retrieving the schedule.
     '''
     set_service_status(Service.SCHEDULE, ServiceStatus.BUSY)
+    n.notify("READY=1")
     while not terminate():
         # Try getting an updated schedule
         get_schedule()
@@ -112,8 +115,10 @@ def control_loop():
         if next_event:
             logger.info('Next scheduled recording: %s',
                         datetime.fromtimestamp(next_event.start))
+            n.notify('STATUS=Next scheduled recording: %s' % datetime.fromtimestamp(next_event.start))
         else:
             logger.info('No scheduled recording')
+            n.notify('STATUS=No scheduled recording')
         session.close()
 
         next_update = timestamp() + config()['agent']['update_frequency']

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ pycurl>=7.19.5
 python-dateutil>=2.4.0
 configobj>=5.0.0
 sqlalchemy>=0.9.8
+sdnotify>=0.3.2
 flask

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         "python-dateutil>=2.4.0",
         "configobj>=5.0.0",
         "sqlalchemy>=0.9.8",
+        "sdnotify>=0.3.2",
         "flask"
     ],
     entry_points={


### PR DESCRIPTION
This PR adds functionality that will notify a possible systemd instance on control loop iterations, allowing the use of `Type=notify` as described in #144. This should help increase resilience against stuck processes which seems to happen with the ingest worker from time to time.

The used library has no dependencies on systemd, it's essentially a small wrapper around the python socket library. It does not raise any issues if pyCA runs on a system that is using a different init system.