### PR TITLE
Use more compatible shebang in start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 exec python -m pyca ${1+"$@"}


### PR DESCRIPTION
The line `#!/bin/bash` doesn’t work with all distributions. A more compatible way of writing this is `#!/usr/bin/env bash`.