### PR TITLE
add: wait for a randomized delay before ingest

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -165,6 +165,15 @@ password         = 'CHANGE_ME'
 # Default: ''
 #certificate     = ''
 
+[ingest]
+
+# Delay ingesting a recorded event for a random amount of second between
+# delay_min and delay_max before trying to ingest a recorded event. delay_max
+# should be higher than or equal to delay_min.
+# Type: integer
+# Default: 0
+#delay_min       = 0
+#delay_max       = 0
 
 [ui]
 

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -40,6 +40,10 @@ password         = string(default='CHANGE_ME')
 insecure         = boolean(default=False)
 certificate      = string(default='')
 
+[ingest]
+delay_max        = integer(min=0, default=0)
+delay_min        = integer(min=0, default=0)
+
 [ui]
 username         = string(default='admin')
 password         = string(default='opencast')

--- a/pyca/db.py
+++ b/pyca/db.py
@@ -38,6 +38,11 @@ def get_session():
     return Session()
 
 
+def get_random_ingest_delay():
+    return random.randint(config()['ingest']['delay_min'],
+                          config()['ingest']['delay_max'])
+
+
 class Constants():
 
     @classmethod
@@ -154,7 +159,8 @@ class RecordedEvent(Base, BaseEvent):
     status = Column('status', Integer(), nullable=False,
                     default=Status.UPCOMING)
     tracks = Column('tracks', LargeBinary(), nullable=True)
-    ingest_delay = Column('ingest_delay', Integer(), nullable=False, default=0)
+    ingest_delay = Column('ingest_delay', Integer(), nullable=False,
+                          default=get_random_ingest_delay)
 
     def __init__(self, event=None):
         if event:
@@ -165,9 +171,6 @@ class RecordedEvent(Base, BaseEvent):
             self.data = event.data
             if hasattr(event, 'status'):
                 self.status = event.status
-            if not hasattr(event, 'ingest_delay'):
-                self.ingest_delay = random.randint(config()['ingest']['delay_min'],
-                                                   config()['ingest']['delay_max'])
 
     def get_tracks(self):
         '''Load JSON track data from event.

--- a/pyca/db.py
+++ b/pyca/db.py
@@ -8,6 +8,7 @@
 
 import json
 import os.path
+import random
 import string
 from pyca.config import config
 from sqlalchemy.ext.declarative import declarative_base
@@ -153,6 +154,7 @@ class RecordedEvent(Base, BaseEvent):
     status = Column('status', Integer(), nullable=False,
                     default=Status.UPCOMING)
     tracks = Column('tracks', LargeBinary(), nullable=True)
+    ingest_delay = Column('ingest_delay', Integer(), nullable=False, default=0)
 
     def __init__(self, event=None):
         if event:
@@ -163,6 +165,9 @@ class RecordedEvent(Base, BaseEvent):
             self.data = event.data
             if hasattr(event, 'status'):
                 self.status = event.status
+            if not hasattr(event, 'ingest_delay'):
+                self.ingest_delay = random.randint(config()['ingest']['delay_min'],
+                                                   config()['ingest']['delay_max'])
 
     def get_tracks(self):
         '''Load JSON track data from event.

--- a/pyca/ingest.py
+++ b/pyca/ingest.py
@@ -130,16 +130,16 @@ def control_loop():
     while not terminate():
         notify.notify('WATCHDOG=1')
 
-        db = get_session()
         # Get next recording without ingest delay
-        event = db.query(RecordedEvent)\
-                  .filter(RecordedEvent.status ==
-                          Status.FINISHED_RECORDING)\
-                  .filter(RecordedEvent.ingest_delay == 0).first()
+        event = get_session().query(RecordedEvent)\
+                             .filter(RecordedEvent.status ==
+                                     Status.FINISHED_RECORDING)\
+                             .filter(RecordedEvent.ingest_delay == 0).first()
         if event:
             safe_start_ingest(event)
 
         # Decrement remaining ingest delays
+        db = get_session()
         db.query(RecordedEvent)\
           .filter(RecordedEvent.status == Status.FINISHED_RECORDING)\
           .filter(RecordedEvent.ingest_delay > 0)\


### PR DESCRIPTION
when many pyCA instances try to ingest large recordings at once, the
ingest server might get overloaded, resulting in timeouts and failed
ingests.

this patch allows the user to configure a randomized time range (in
seconds, min and max) that pyCA will wait before trying to ingest a
finished recording, which will spread out the load on the ingest server.

---
Implements feature proposal in #162.

I'm not too happy with the implementation of the delay decrementing, but it shouldn't be too critical in this case. I would rather like to see the decrementing happen directly via SQL, but I'm not too versed in SQLalchemy.