### PR TITLE
Update Agent State Properly

### DIFF
--- a/pyca/agentstate.py
+++ b/pyca/agentstate.py
@@ -27,11 +27,13 @@ def control_loop():
     notify.notify('STATUS=Running')
     while not terminate():
         notify.notify('WATCHDOG=1')
-        update_agent_state()
 
         next_update = timestamp() + config()['agent']['update_frequency']
         while not terminate() and timestamp() < next_update:
             time.sleep(0.1)
+
+        if not terminate():
+            update_agent_state()
 
     logger.info('Shutting down agentstate service')
     set_service_status(Service.AGENTSTATE, ServiceStatus.STOPPED)

--- a/pyca/capture.py
+++ b/pyca/capture.py
@@ -163,7 +163,7 @@ def control_loop():
     '''Main loop of the capture agent, retrieving and checking the schedule as
     well as starting the capture process if necessry.
     '''
-    set_service_status(Service.CAPTURE, ServiceStatus.IDLE)
+    set_service_status_immediate(Service.CAPTURE, ServiceStatus.IDLE)
     notify.notify('READY=1')
     notify.notify('STATUS=Waiting')
     while not terminate():

--- a/pyca/ingest.py
+++ b/pyca/ingest.py
@@ -124,7 +124,7 @@ def control_loop():
     '''Main loop of the capture agent, retrieving and checking the schedule as
     well as starting the capture process if necessry.
     '''
-    set_service_status(Service.INGEST, ServiceStatus.IDLE)
+    set_service_status_immediate(Service.INGEST, ServiceStatus.IDLE)
     notify.notify('READY=1')
     notify.notify('STATUS=Running')
     while not terminate():

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -7,8 +7,8 @@
     :license: LGPL – see license.lgpl for more details.
 '''
 
-from pyca.utils import http_request, configure_service, unix_ts, timestamp
-from pyca.utils import set_service_status, terminate
+from pyca.utils import http_request, configure_service, unix_ts, timestamp, \
+                       set_service_status_immediate, terminate
 from pyca.config import config
 from pyca.db import get_session, UpcomingEvent, Service, ServiceStatus
 from base64 import b64decode
@@ -102,7 +102,7 @@ def get_schedule():
 def control_loop():
     '''Main loop, retrieving the schedule.
     '''
-    set_service_status(Service.SCHEDULE, ServiceStatus.BUSY)
+    set_service_status_immediate(Service.SCHEDULE, ServiceStatus.BUSY)
     notify.notify('READY=1')
     while not terminate():
         notify.notify('WATCHDOG=1')
@@ -128,7 +128,7 @@ def control_loop():
             time.sleep(0.1)
 
     logger.info('Shutting down schedule service')
-    set_service_status(Service.SCHEDULE, ServiceStatus.STOPPED)
+    set_service_status_immediate(Service.SCHEDULE, ServiceStatus.STOPPED)
 
 
 def run():

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -33,6 +33,7 @@ class TestPycaCapture(unittest.TestCase):
         self.fd, self.dbfile = tempfile.mkstemp()
         config.config()['agent']['database'] = 'sqlite:///' + self.dbfile
         config.config()['service-scheduler'] = ['']
+        config.config()['service-capture.admin'] = ['']
 
         # Mock event
         db.init()


### PR DESCRIPTION
pyCA's status is set by the agent state service which is not guaranteed
to start or stop before or after any of the other processes upon which
the current status is based. This may lead to race conditions when
starting or stopping pyCA in which cases:

- pyCA may appear as offline after it is started
- pyCA may not be set to offline after it is shut down

While this issue does not have any negative effect on recording
capabilities (pyCA will still record even if the state is still set to
offline), this may cause some confusion.

This patch fixes the problem by setting the state immediately after
relevant services are started and when they are shut down.

*This fixes the issue mentioned at https://github.com/opencast/opencast/pull/622#issuecomment-463996967*