### PR TITLE
Add Data Files to Python Package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include pyca/ui/static/*
+include pyca/ui/templates/*

--- a/pyca/ui/__init__.py
+++ b/pyca/ui/__init__.py
@@ -9,7 +9,12 @@ from pyca.db import get_session
 from pyca.ui.utils import dtfmt, requires_auth
 from pyca.utils import get_service_status
 import os.path
-app = Flask(__name__)
+
+__base_dir__ = os.path.abspath(os.path.dirname(__file__))
+app = Flask(
+    __name__,
+    template_folder=os.path.join(__base_dir__, 'templates'),
+    static_folder=os.path.join(__base_dir__, 'static'))
 import pyca.ui.jsonapi  # noqa
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     license="LGPLv3",
     url="https://github.com/opencast/pyCA",
     packages=find_packages(),
+    include_package_data=True,
     install_requires=[
         "pycurl>=7.19.5",
         "python-dateutil>=2.4.0",


### PR DESCRIPTION
This patch adds the data files in `pyca/ui/static/` and `pyca/ui/templates/` to
the python package and changes the internal references accordingly.

This way the UI can be started from an arbitrary working directory after pyCA
is installed and not only from within this repository.