### PR TITLE
Introduce some nginx examples

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -131,6 +131,9 @@ using Gunicorn, would be to run::
 For more information, have a look at the help option of gunicorn or go to the
 `Gunicorn online documentation`_.
 
+In addition to the WSGI server, you should use a reverse proxy,
+if you want the ui to listen to anything but `localhost`.
+Some example configuration files for Nginx_ can be found under `reverse-proxy <reverse-proxy>`_.
 
 JSON API
 ********
@@ -175,6 +178,7 @@ file while simultaneously updating a still image every second.
 .. _Opencast: https://opencast.org
 .. _GNU Lesser General Public License: https://raw.githubusercontent.com/opencast/pyCA/master/license.lgpl
 .. _Raspberry Pi: https://raspberrypi.org
+.. _Nginx: https://www.nginx.com
 .. _AUR: https://aur.archlinux.org/packages/pyca
 .. _Gunicorn online documentation: https://gunicorn.org
 .. _Travis configuration: https://raw.githubusercontent.com/opencast/pyCA/master/.travis.yml

--- a/reverse-proxy/nginx-tls.conf
+++ b/reverse-proxy/nginx-tls.conf
@@ -1,0 +1,26 @@
+# <server_name must be replaced with the actuall server name>
+#
+# If installed, the snakeoil certificate is an automatically generated self
+# signed certificate. For a proper installation a proper certificate like one
+# from https://letsencrypt.org/ is needed.
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+    location / {
+        return 302 https://<server_name>$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name <server_name>;
+    ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
+    ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+    }
+}

--- a/reverse-proxy/nginx.conf
+++ b/reverse-proxy/nginx.conf
@@ -1,0 +1,7 @@
+server {
+    listen 80;
+    listen [::]:80;
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+    }
+}


### PR DESCRIPTION
To make it easier to use a reverse proxy with PyCA, this patch add some example
configuration files for nginx.