### PR TITLE
Fix Configuration Load Order

### DIFF
--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -31,8 +31,8 @@ OPTIONS:
 CONFIGURATION:
   PyCA will try to find a configuration in the following order:
    - Configuration specified on the command line
-   - /etc/pyca.conf
    - ./etc/pyca.conf
+   - /etc/pyca.conf
 '''
 
 


### PR DESCRIPTION
This patch fixes the documentation, describing in which order the
pyCA is looking for configuration files.