### PR TITLE
Use Unique Agent Name

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -10,8 +10,8 @@
 
 # Name of the capture agent
 # Type: string
-# Default: pyca
-name             = 'pyca'
+# Default: pyca@<hostname>
+#name             = 'pyca'
 
 # How often (in seconds) should the capture agent try to get an updated
 # schedule from the core.

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -7,6 +7,7 @@ import configobj
 import logging
 import logging.handlers
 import os
+import socket
 import sys
 from validate import Validator
 
@@ -14,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 __CFG = '''
 [agent]
-name             = string(default='pyca')
+name             = string(default='')
 update_frequency = integer(min=5, default=60)
 cal_lookahead    = integer(min=0, default=14)
 backup_mode      = boolean(default=false)
@@ -86,6 +87,8 @@ def update_configuration(cfgfile=None):
         raise ValueError('Invalid configuration: %s' % val)
     if len(cfg['capture']['files']) != len(cfg['capture']['flavors']):
         raise ValueError('List of files and flavors do not match')
+    if not cfg['agent']['name']:
+        cfg['agent']['name'] = 'pyca@' + socket.gethostname()
     globals()['__config'] = cfg
     logger_init()
     if cfg['server'].get('url', '').endswith('/'):


### PR DESCRIPTION
This patch switches the default agent name from `pyca` to
`pyca@<hostname>` which is more likely to be unique.

This helps avoiding scheduling conflicts when people just try out pyCA
with the default configuration.