### PR TITLE
Service Configuration and Management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: lint test
 
 lint:
-	@flake8 $$(find . -name '*.py')
+	@flake8 $$(find pyca tests -name '*.py')
 
 test:
 	@npm run build

--- a/etc/gunicorn.conf.py
+++ b/etc/gunicorn.conf.py
@@ -1,0 +1,19 @@
+import multiprocessing
+
+# Gunicorn configuration for pyCA user interface
+#
+# For details of the available optiuons see:
+# https://docs.gunicorn.org/en/stable/settings.html#settings
+
+# The socket to bind.
+# This can be a TCP socket:
+#   bind = "127.0.0.1:8000"
+# …or a UNIX socket:
+#   bind = "unix:/var/run/pyca/uisocket"
+#
+# Default: "127.0.0.1:8000"
+#bind = "127.0.0.1:8000"
+
+# The number of worker processes for handling requests.
+# Default: 1
+workers = multiprocessing.cpu_count()

--- a/init/systemd/pyca-agentstate.service
+++ b/init/systemd/pyca-agentstate.service
@@ -2,6 +2,8 @@
 Description=Python Capture Agent agentstate service
 Documentation=https://github.com/opencast/pyCA
 Wants=network.target
+PartOf=pyca.service
+After=pyca.service
 
 [Service]
 Type=notify
@@ -14,4 +16,4 @@ RestartSec=10
 TimeoutSec=300
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=pyca.service

--- a/init/systemd/pyca-capture.service
+++ b/init/systemd/pyca-capture.service
@@ -2,6 +2,8 @@
 Description=Python Capture Agent capture service
 Documentation=https://github.com/opencast/pyCA
 Wants=network.target
+PartOf=pyca.service
+After=pyca.service
 
 [Service]
 Type=notify
@@ -14,4 +16,4 @@ RestartSec=10
 TimeoutSec=300
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=pyca.service

--- a/init/systemd/pyca-ingest.service
+++ b/init/systemd/pyca-ingest.service
@@ -2,6 +2,8 @@
 Description=Python Capture Agent ingest service
 Documentation=https://github.com/opencast/pyCA
 Wants=network.target
+PartOf=pyca.service
+After=pyca.service
 
 [Service]
 Type=notify
@@ -14,4 +16,4 @@ RestartSec=10
 TimeoutSec=300
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=pyca.service

--- a/init/systemd/pyca-schedule.service
+++ b/init/systemd/pyca-schedule.service
@@ -2,6 +2,8 @@
 Description=Python Capture Agent schedule service
 Documentation=https://github.com/opencast/pyCA
 Wants=network.target
+PartOf=pyca.service
+After=pyca.service
 
 [Service]
 Type=notify
@@ -14,4 +16,4 @@ RestartSec=10
 TimeoutSec=300
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=pyca.service

--- a/init/systemd/pyca-ui.service
+++ b/init/systemd/pyca-ui.service
@@ -2,13 +2,15 @@
 Description=Python Capture Agent UI instance
 Documentation=https://github.com/opencast/pyCA
 Wants=network.target
+PartOf=pyca.service
+After=pyca.service
 
 [Service]
 Type=simple
 User=pyca
-ExecStart=/usr/bin/gunicorn pyca.ui:app
+ExecStart=/usr/bin/gunicorn --config=/etc/pyca/gunicorn.conf.py pyca.ui:app
 Restart=always
 RestartSec=10
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=pyca.service

--- a/init/systemd/pyca.service
+++ b/init/systemd/pyca.service
@@ -1,16 +1,11 @@
 [Unit]
-Description=Python Capture Agent
-Documentation=https://github.com/opencast/pyCA
-Wants=network.target
-PartOf=pyca.target
+Description=PyCA
 
 [Service]
-Type=simple
-User=pyca
-ExecStart=/usr/bin/pyca
-Restart=always
-RestartSec=10
-TimeoutSec=300
+Type=oneshot
+ExecStart=/bin/true
+# Considered unit active after start
+RemainAfterExit=yes
 
 [Install]
-WantedBy=pyca.target
+WantedBy=multi-user.target

--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -32,7 +32,7 @@ CONFIGURATION:
   PyCA will try to find a configuration in the following order:
    - Configuration specified on the command line
    - ./etc/pyca.conf
-   - /etc/pyca.conf
+   - /etc/pyca/pyca.conf
 '''
 
 

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -68,7 +68,7 @@ def configuration_file(cfgfile):
     # location.
     cfg = './etc/pyca.conf'
     if not os.path.isfile(cfg):
-        return '/etc/pyca.conf'
+        return '/etc/pyca/pyca.conf'
     return cfg
 
 

--- a/readme.rst
+++ b/readme.rst
@@ -58,8 +58,8 @@ Here is a short summary how to use it.
   apt-get install opencast-pyca
 
 Once installed, you can use your regular update mechanisms to keep PyCA up to date.
-The configuration can be found unter `/etc/pyca.conf` and contains reasonable defaults.
-All PyCA components will be started automatically and you can reach the UI under http://localhost:8000.
+The configuration can be found at `/etc/pyca/pyca.conf` and contains reasonable defaults.
+All PyCA components will be started automatically and you can reach the user interface at http://localhost:8000.
 
 On Fedora ≥ 31 or CentOS 8::
 


### PR DESCRIPTION
This patch overhauls the Systemd services. It adds a master service to
allow for easier management of pyCA, starting and stopping it using one
easy command. It also changes the main configuration location to allow
for multiple configuration files.

The master service controls all other services, allowing to use the
following commands to shut them down as well:

    systemctl start pyca.service
    systemctl stop pyca.service
    systemctl restart pyca.service

Not that for this to work, the other services must be anabled. This also
means that you can still exclude services like the user interface by
disabling them. Usually, though, you want to run this to ensure pyCA is
fully functional as service:

    systemctl enable pyca-agentstate.service
    systemctl enable pyca-capture.service
    systemctl enable pyca-ingest.service
    systemctl enable pyca-schedule.service
    systemctl enable pyca-ui.service

The main configuration file is now located at `/etc/pyca/pyca.conf` The
additional sirectory ensures that additional configuration files can be
stored. One new default configuration is `/etc/pyca/gunicorn.conf.py`
which is included in the Systemd unit file for the user interface and
for which a default one is included in the `etc` folder.