### PR TITLE
Fix SQLite Threading Problem

### DIFF
--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -112,7 +112,7 @@ def main():
         agentstate.run()
     elif cmd == 'ui':
         signal.signal(signal.SIGINT, signal.default_int_handler)
-        ui.app.run()
+        ui.app.run(threaded=False)
     else:
         # Invalid command
         usage(3)


### PR DESCRIPTION
Using the development server, SQLite complains that objects created in a
thread can only be used in that same thread.

The reason why this only happens in modern systems and did not appear in
the past is probably Flask's newish threading concept. The error does
not seem to appear with gunicorn when workers are being used. The error
also did not appear on older systems with older Flask versions.

However, Flask ≥ 1.0 did enable threading by default so the development
server would perform better. Deactivating this makes the execution
single-threaded again and the error disappears.

This shouldn't really be a huge problem given that this is for
development and we don't do many large requests.

This fixes #174