### PR TITLE
JSON API match json:api formatting

### DIFF
--- a/apidocs.rst
+++ b/apidocs.rst
@@ -9,6 +9,46 @@ default.
 .. contents::
 
 
+GET /api/name
+-------------
+
+A JSON representation of name of the pyCA instance.
+
+cURL example::
+
+  % curl -u admin:opencast \
+      -H 'content-type: application/vnd.api+json' \
+      'http://127.0.0.1:5000/api/name'
+  {
+    "meta": {
+      "name": "pyca"
+    }
+  }
+
+
+GET /api/previews
+-----------------
+
+A JSON representation of the current available previews.
+
+cURL example::
+
+  % curl -u admin:opencast \
+      -H 'content-type: application/vnd.api+json' \
+      'http://127.0.0.1:5000/api/previews'
+  {
+    "data": [
+      {
+        "attributes": {
+          "id": 1
+        },
+        "id": "1",
+        "type": "preview"
+      }
+    ]
+  }
+
+
 GET /api/services
 -----------------
 

--- a/pyca/ui/jsonapi.py
+++ b/pyca/ui/jsonapi.py
@@ -38,7 +38,7 @@ def make_data_response(data, status=200):
 def get_name():
     '''Serve the name of the capure agent via json.
     '''
-    return make_response({'name': config()['agent']['name']})
+    return make_response({'meta': {'name': config()['agent']['name']}})
 
 
 @app.route('/api/previews')
@@ -54,7 +54,8 @@ def get_images():
     preview = zip(preview, range(len(preview)))
 
     # Create return
-    preview = [{'id': p[1]} for p in preview if os.path.isfile(p[0])]
+    preview = [{'attributes': {'id': p[1]}, 'id': str(p[1]), 'type': 'preview'}
+               for p in preview if os.path.isfile(p[0])]
     return make_data_response(preview)
 
 
@@ -69,8 +70,7 @@ def internal_state():
         'ingest': ServiceStatus.str(get_service_status(Service.INGEST)),
         'schedule': ServiceStatus.str(get_service_status(Service.SCHEDULE)),
         'agentstate': ServiceStatus.str(get_service_status(Service.AGENTSTATE))
-        }
-    }
+    }}
     return make_response(jsonify({'meta': data}))
 
 
@@ -87,12 +87,9 @@ def events():
     recorded_events = db.query(RecordedEvent)\
                         .order_by(RecordedEvent.start.desc())
 
-    upcoming = [event.serialize() for event in upcoming_events]
-    recorded = [event.serialize() for event in recorded_events]
-    return make_response({
-        'upcoming': upcoming,
-        'recorded': recorded,
-    })
+    result = [event.serialize() for event in upcoming_events]
+    result += [event.serialize() for event in recorded_events]
+    return make_data_response(result)
 
 
 @app.route('/api/events/<uid>')

--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -78,8 +78,7 @@ class TestPycaRestInterface(unittest.TestCase):
             assert response.status_code == 200
             assert response.headers['Content-Type'] == self.content_type
             self.assertEqual(json.loads(
-                response.data.decode('utf-8')),
-                {'upcoming': [], 'recorded': []})
+                response.data.decode('utf-8')), dict(data=[]))
 
         # With authentication and event
         event = self.add_test_event()
@@ -87,7 +86,7 @@ class TestPycaRestInterface(unittest.TestCase):
             response = ui.jsonapi.events()
             assert response.status_code == 200
             assert response.headers['Content-Type'] == self.content_type
-            events = json.loads(response.data.decode('utf-8'))['recorded'][0]
+            events = json.loads(response.data.decode('utf-8'))['data'][0]
             assert events.get('id') == event.uid
 
     def test_event(self):

--- a/ui/func.js
+++ b/ui/func.js
@@ -29,7 +29,7 @@ var update_data = function () {
     // Get capture agent name.
     axios
         .get('/api/name')
-        .then(response => data.name = response.data.name);
+        .then(response => data.name = response.data.meta.name);
     // Get services.
     axios
         .get('/api/services')
@@ -39,18 +39,22 @@ var update_data = function () {
         });
     // Get events.
     axios
-        .get('/api/events')
+        .get('/api/events/')
         .then(response => {
-            data.upcoming = response.data.upcoming.length;
-            data.processed = response.data.recorded.length;
-            data.upcoming_events = response.data.upcoming.map(x => create_event(x, 'upcoming'));
-            data.recorded_events = response.data.recorded.map(x => create_event(x, x.attributes.status));
+            data.upcoming_events = response.data.data.filter(
+                x => x.attributes.status === "upcoming").map(
+                    x => create_event(x, x.attributes.status));
+            data.upcoming = data.upcoming_events.length;
+            data.recorded_events = response.data.data.filter(
+                x => x.attributes.status !== "upcoming").map(
+                    x => create_event(x, x.attributes.status));
+            data.processed = data.recorded_events.length;
         });
     // Get preview images.
     axios
         .get('/api/previews')
         .then(response => {
-            data.previews = response.data.data.map(x => "/img/" + x.id + "?" + Date.now());
+            data.previews = response.data.data.map(x => "/img/" + x.attributes.id + "?" + Date.now());
         });
 };
 


### PR DESCRIPTION
This patch fixes some flaws in the json api to fulfill the [JSON:API specification](https://jsonapi.org) again.

There is a minor change in functionality here:
Before this patch upcoming events where events from the `upcoming_event` database table and recorded events from the database table `recorded_event`.
Now upcoming events are all events from `/api/events` with `status === upcoming` and recorded all remaining events.