### PR TITLE
Add 'Last Schedule Update' to metrics

### DIFF
--- a/pyca/db.py
+++ b/pyca/db.py
@@ -11,8 +11,10 @@ import os.path
 import string
 from pyca.config import config
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, Text, LargeBinary, create_engine
+from sqlalchemy import Column, Integer, Text, LargeBinary, DateTime, \
+    create_engine
 from sqlalchemy.orm import sessionmaker
+from datetime import datetime
 Base = declarative_base()
 
 
@@ -156,8 +158,8 @@ class BaseEvent():
                 'title': self.title,
                 'data': self.get_data(),
                 'status': Status.str(self.status)
-                }
             }
+        }
 
 
 class UpcomingEvent(Base, BaseEvent):
@@ -194,3 +196,17 @@ class ServiceStates(Base):
         if service:
             self.type = service.type
             self.status = service.status
+
+
+class UpstreamState(Base):
+    '''State of the upstream Opencast server.'''
+    __tablename__ = 'upstream_state'
+    url = Column('url', Text(), primary_key=True)
+    last_synced = Column('last_synced', DateTime())
+
+    @staticmethod
+    def update_sync_time(url):
+        s = get_session()
+        s.merge(UpstreamState(url=url, last_synced=datetime.utcnow()))
+        s.commit()
+        s.close()

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -10,7 +10,8 @@
 from pyca.utils import http_request, configure_service, unix_ts, timestamp, \
                        set_service_status_immediate, terminate
 from pyca.config import config
-from pyca.db import get_session, UpcomingEvent, Service, ServiceStatus
+from pyca.db import get_session, UpcomingEvent, Service, ServiceStatus, \
+    UpstreamState
 from base64 import b64decode
 from datetime import datetime
 import dateutil.parser
@@ -73,6 +74,7 @@ def get_schedule():
                                urlencode(params))
     try:
         vcal = http_request(uri)
+        UpstreamState.update_sync_time(config()['server']['url'])
     except pycurl.error as e:
         logger.error('Could not get schedule: %s' % e)
         return

--- a/ui/func.js
+++ b/ui/func.js
@@ -124,6 +124,21 @@ var update_data = function () {
             if (services.metrics && services.metrics.length) {
                 data.metrics.push(services)
             }
+
+            // Upstream related metrics
+            const upstream = {
+                'header': 'Upstream',
+                'metrics': [{
+                    'name': 'Last Schedule Update',
+                    'value': response.data.meta.upstream.last_synchronized ?
+                        Date(response.data.meta.upstream.last_synchronized).toString() :
+                        'never'
+                }]
+            };
+            // Add upstream metrics
+            if (upstream.metrics && upstream.metrics.length) {
+                data.metrics.push(upstream)
+            }
         });
 };
 


### PR DESCRIPTION
This patch add a 'Last Schedule Update' to the metrics api endpoint. To achieve
this a new state is introduced into the database and updated every time the
scheduler is reaching for the upstream Opencast server.