### PR TITLE
Fix Dates in UI

### DIFF
--- a/ui/func.js
+++ b/ui/func.js
@@ -19,8 +19,8 @@ var data = {
 // create_event creates entries for the event list.
 var create_event = function (event, status) {
     return {
-        'start': new Date(event.attributes.start).toLocaleString(),
-        'end': new Date(event.attributes.end).toLocaleString(),
+        'start': new Date(event.attributes.start * 1000).toLocaleString(),
+        'end': new Date(event.attributes.end * 1000).toLocaleString(),
         'status': status,
     };
 }


### PR DESCRIPTION
`Date` is using milliseconds in the constructor for timestamps, but we are using seconds.

This patch fixes this circumstance.