### PR TITLE
Fix Block Width of Recoding State

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -46,7 +46,7 @@ summary {
 
 #status > div {
     display: inline-block;
-    width: 90px;
+    min-width: 90px;
     height: 75px;
     margin: 5px;
     padding: 20px;


### PR DESCRIPTION
This patch fixes the user interface displaying an active recording
state in the header which was too width for the fixed size block.

---

Before
![Screenshot from 2020-06-12 23-04-49](https://user-images.githubusercontent.com/1008395/84546649-13af0b00-ad02-11ea-9e33-61c0279d6fef.png)

After:
![Screenshot from 2020-06-12 23-04-42](https://user-images.githubusercontent.com/1008395/84546648-13167480-ad02-11ea-9d1d-0d79003a10cf.png)