### PR TITLE
Handle partial recordings

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -78,7 +78,7 @@ directory        = './recordings'
 # Default: ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -t {{time}} {{dir}}/{{name}}.webm'
 command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -f lavfi -i sine -t {{time}} {{dir}}/{{name}}.webm'
 
-# Flavors of putput files produced by the capture command. One flavors should
+# Flavors of output files produced by the capture command. One flavors should
 # be specified for every output file.
 # Type: list of strings (write as '...', '...')
 # Default: 'presenter/source'

--- a/pyca/db.py
+++ b/pyca/db.py
@@ -82,6 +82,7 @@ class Status(Constants):
     UPLOADING = 5
     FAILED_UPLOADING = 6
     FINISHED_UPLOADING = 7
+    PARTIAL_RECORDING = 8
 
 
 class ServiceStatus(Constants):


### PR DESCRIPTION
This patch handles the failure of recordings, by introducing a new state for
partial recordings.

Old partial recordings are kept and moved out of the way.
The process is stopped after recording and marked as a partial recording, so
that disaster recovery can take over.

Closes #137