### PR TITLE
Run gunicorn from within Python

### DIFF
--- a/init/systemd/pyca-ui.service
+++ b/init/systemd/pyca-ui.service
@@ -8,7 +8,7 @@ After=pyca.service
 [Service]
 Type=simple
 User=pyca
-ExecStart=/usr/bin/gunicorn --config=/etc/pyca/gunicorn.conf.py pyca.ui:app
+ExecStart=/usr/bin/python3 -m gunicorn.app.wsgiapp --config=/etc/pyca/gunicorn.conf.py pyca.ui:app
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
This patch changes the ui service file to run gunicorn not from the system's
binary, but from Python as a module.

This way we can support a broader list of OSs since the gunicorn binary for
Python 3 does have different names for different OSs.

Closes #183