### PR TITLE
Drop Python 2 Support

### DIFF
--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -18,13 +18,9 @@ import dateutil.parser
 import logging
 import pycurl
 import sdnotify
-import sys
 import time
 import traceback
-if sys.version_info[0] == 2:
-    from urllib import urlencode
-else:
-    from urllib.parse import urlencode
+from urllib.parse import urlencode
 
 logger = logging.getLogger(__name__)
 notify = sdnotify.SystemdNotifier()

--- a/pyca/utils.py
+++ b/pyca/utils.py
@@ -17,14 +17,9 @@ import logging
 import os
 import os.path
 import pycurl
-import sys
 import time
-if sys.version_info[0] == 2:
-    from cStringIO import StringIO as bio
-    from urllib import quote as urlquote
-else:
-    from io import BytesIO as bio
-    from urllib.parse import quote as urlquote
+from io import BytesIO as bio
+from urllib.parse import quote as urlquote
 
 
 logger = logging.getLogger(__name__)

--- a/readme.rst
+++ b/readme.rst
@@ -25,13 +25,7 @@ devices like the `Raspberry Pi`_.
 Python Versions
 ***************
 
-PyCA supports both Python 2 and Python 3. For Python 2, we only support
-version 2.7, while for Python 3 we test against all recent versions. For a
-detailed list of supported versions, have a look at the `Travis
-configuration`_.
-
-While we will continue to support Python 2 until the end of 2019, we recommend using
-Python 3 if possible.
+PyCA requires Python ≥ 3.6. Older versions of Python will not work.
 
 Installation
 ************


### PR DESCRIPTION
Python 2 has officially reached its end-of-life and there are already
patches coming in which break support of older Python versions against
which no one tests anymore anyway.

That is why this patches drops the Python 2 support, adjusting the
documentation and removing the Python 2 specific code branches.