### PR TITLE
Allow HTTP Basic Authentication

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -148,6 +148,20 @@ url              = 'https://develop.opencast.org'
 # Default: False
 #insecure         = False
 
+# Authentication Method
+#
+# Historically, capture agents use HTTP digest authentication. The downside of
+# this is, that all users need to be specified in the backend configuration
+# files. Instead, HTTP Basic authentication can be used with front-end users
+# (users created in the web interface). Whatever you use, make sure the user
+# has appropriate rights (e.g. ROLE_CAPTURE_AGENT) to communicate with the
+# capture agent API in Opencast.
+#
+# Type: options
+# Allowed values: basic, digest
+# Default: digest
+#auth_method = 'digest'
+
 # Username for the admin server (digest authentication)
 # Type: string
 # Default: opencast_system_account

--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -162,12 +162,12 @@ url              = 'https://develop.opencast.org'
 # Default: digest
 #auth_method = 'digest'
 
-# Username for the admin server (digest authentication)
+# Username for the admin server
 # Type: string
 # Default: opencast_system_account
 username         = 'opencast_system_account'
 
-# Password for the admin server (digest authentication)
+# Password for the admin server
 # Type: string
 # Default: CHANGE_ME
 password         = 'CHANGE_ME'

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -36,6 +36,7 @@ exit_code        = integer(min=0, max=255, default=0)
 
 [server]
 url              = string(default='https://develop.opencast.org')
+auth_method      = option('basic', 'digest', default='digest')
 username         = string(default='opencast_system_account')
 password         = string(default='CHANGE_ME')
 insecure         = boolean(default=False)

--- a/pyca/utils.py
+++ b/pyca/utils.py
@@ -48,10 +48,13 @@ def http_request(url, post_data=None):
     if post_data:
         curl.setopt(curl.HTTPPOST, post_data)
     curl.setopt(curl.WRITEFUNCTION, buf.write)
-    curl.setopt(pycurl.HTTPAUTH, pycurl.HTTPAUTH_DIGEST)
+    logger.debug('Using authentication method %s',
+                 config('server')['auth_method'])
+    if config('server')['auth_method'] == 'digest':
+        curl.setopt(curl.HTTPHEADER, ['X-Requested-Auth: Digest'])
+        curl.setopt(pycurl.HTTPAUTH, pycurl.HTTPAUTH_DIGEST)
     curl.setopt(pycurl.USERPWD, ':'.join([config('server', 'username'),
                                           config('server', 'password')]))
-    curl.setopt(curl.HTTPHEADER, ['X-Requested-Auth: Digest'])
     curl.setopt(curl.FAILONERROR, True)
     curl.setopt(curl.FOLLOWLOCATION, True)
     curl.perform()


### PR DESCRIPTION
For historic reasons, capture agents talking to Opencast use HTTP Digest
authentication. While this works perfectly fine, it is unnecessarily
complicated and has comes with the downside that capture agent user
cannot be created via web interface.

This patch allows users to choose between basic and digest
authentication, allowing for any user to be used with pyCA.