### PR TITLE
Make PyCA compatible with older flask version

### DIFF
--- a/pyca/ui/jsonapi.py
+++ b/pyca/ui/jsonapi.py
@@ -40,7 +40,8 @@ def make_data_response(data, status=200):
 def get_name():
     '''Serve the name of the capure agent via json.
     '''
-    return make_response({'meta': {'name': config()['agent']['name']}})
+    return make_response(
+        jsonify({'meta': {'name': config()['agent']['name']}}))
 
 
 @app.route('/api/previews')
@@ -202,7 +203,7 @@ def metrics(dbs):
     state = dbs.query(UpstreamState).filter(
         UpstreamState.url == config()['server']['url']).first()
     last_synchronized = state.last_synced.isoformat() if state else None
-    return make_response(
+    return make_response(jsonify(
         {'meta': {
             'services': services,
             'disk_usage_in_bytes': {
@@ -226,4 +227,4 @@ def metrics(dbs):
             'upstream': {
                 'last_synchronized': last_synchronized,
             }
-        }})
+        }}))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ configobj>=5.0.0
 sqlalchemy>=0.9.8
 sdnotify>=0.3.2
 psutil>=5.0.1
-flask
+flask>=1.0.2

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "sqlalchemy>=0.9.8",
         "sdnotify>=0.3.2",
         "psutil>=5.0.1",
-        "flask"
+        "flask>=1.0.2",
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Implicit conversions of doictionaries to JSON is a feature introduced in Flask
1.1.0, but we want to support Flask until version 1.0.2 to support the current
Debian. So this patch introduces explicit calls of `jsonify`.