### PR TITLE
Fix metrics endpoint for non-existent capture dir

### DIFF
--- a/pyca/ui/jsonapi.py
+++ b/pyca/ui/jsonapi.py
@@ -182,7 +182,11 @@ def metrics(dbs):
     '''Serve several metrics about the pyCA services and the machine via
     json.'''
     # Get Disk Usage
-    total, used, free = shutil.disk_usage(config()['capture']['directory'])
+    # If the capture directory do not exists, use the parent directory.
+    directory = config()['capture']['directory']
+    if not os.path.exists(directory):
+        directory = os.path.abspath(os.path.join(directory, os.pardir))
+    total, used, free = shutil.disk_usage(directory)
 
     # Get Loads
     load_1m, load_5m, load_15m = os.getloadavg()


### PR DESCRIPTION
This patch let the metrics endpoint use the parent directory of the capture
directory, if it is non-existent to calculate the disk usage.