### PR TITLE
Simplify Configuration Access

### DIFF
--- a/pyca/agentstate.py
+++ b/pyca/agentstate.py
@@ -28,7 +28,7 @@ def control_loop():
     while not terminate():
         notify.notify('WATCHDOG=1')
 
-        next_update = timestamp() + config()['agent']['update_frequency']
+        next_update = timestamp() + config('agent', 'update_frequency')
         while not terminate() and timestamp() < next_update:
             time.sleep(0.1)
 

--- a/pyca/capture.py
+++ b/pyca/capture.py
@@ -56,7 +56,7 @@ def start_capture(upcoming_event):
         db.add(event)
         db.commit()
 
-    try_mkdir(config()['capture']['directory'])
+    try_mkdir(config('capture', 'directory'))
     try_mkdir(event.directory())
 
     # Set state
@@ -67,7 +67,7 @@ def start_capture(upcoming_event):
     # Recording
     files = recording_command(event)
     # [(flavor,path),…]
-    event.set_tracks(list(zip(config('capture')['flavors'], files)))
+    event.set_tracks(list(zip(config('capture', 'flavors'), files)))
     db.commit()
 
     # Set status
@@ -171,7 +171,7 @@ def recording_command(event):
             logger.warning(traceback.format_exc())
 
     # Check process for errors
-    exitcode = config()['capture']['exit_code']
+    exitcode = conf['exit_code']
     if captureproc.poll() > 0 and captureproc.returncode != exitcode:
         raise RuntimeError('Recording failed (%i)' % captureproc.returncode)
 

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -114,9 +114,20 @@ def check():
                     'Opencast')
 
 
-def config(key=None):
+def config(*args):
+    '''Get a specific configuration value or the whole configuration, loading
+    the configuration file if it was not before.
+
+    :param key: optional configuration key to return
+    :type key: string
+    :return: dictionary containing the configuration or configuration value
+    '''
     cfg = __config or update_configuration()
-    return cfg[key] if key else cfg
+    for key in args:
+        if cfg is None:
+            return
+        cfg = cfg.get(key)
+    return cfg
 
 
 def logger_init():

--- a/pyca/db.py
+++ b/pyca/db.py
@@ -24,7 +24,7 @@ def init():
     structure will be created if nonexistent.
     '''
     global engine
-    engine = create_engine(config()['agent']['database'])
+    engine = create_engine(config('agent', 'database'))
     Base.metadata.create_all(engine)
 
 
@@ -136,7 +136,7 @@ class BaseEvent():
     def directory(self):
         '''Returns recording directory of this event.
         '''
-        return os.path.join(config()['capture']['directory'], self.name())
+        return os.path.join(config('capture', 'directory'), self.name())
 
     def remaining_duration(self, time):
         '''Returns the remaining duration for a recording.

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -62,15 +62,15 @@ def get_schedule():
     '''Try to load schedule from the Matterhorn core. Returns a valid schedule
     or None on failure.
     '''
-    params = {'agentid': config()['agent']['name'].encode('utf8')}
-    lookahead = config()['agent']['cal_lookahead'] * 24 * 60 * 60
+    params = {'agentid': config('agent', 'name').encode('utf8')}
+    lookahead = config('agent', 'cal_lookahead') * 24 * 60 * 60
     if lookahead:
         params['cutoff'] = str((timestamp() + lookahead) * 1000)
-    uri = '%s/calendars?%s' % (config()['service-scheduler'][0],
+    uri = '%s/calendars?%s' % (config('service-scheduler')[0],
                                urlencode(params))
     try:
         vcal = http_request(uri)
-        UpstreamState.update_sync_time(config()['server']['url'])
+        UpstreamState.update_sync_time(config('server', 'url'))
     except pycurl.error as e:
         logger.error('Could not get schedule: %s', e)
         return
@@ -121,7 +121,7 @@ def control_loop():
             notify.notify('STATUS=No scheduled recording')
         session.close()
 
-        next_update = timestamp() + config()['agent']['update_frequency']
+        next_update = timestamp() + config('agent', 'update_frequency')
         while not terminate() and timestamp() < next_update:
             time.sleep(0.1)
 

--- a/pyca/ui/__init__.py
+++ b/pyca/ui/__init__.py
@@ -20,7 +20,7 @@ import pyca.ui.jsonapi  # noqa
 def home():
     '''Serve the status page of the capture agent.
     '''
-    refresh_rate = config()['ui']['refresh_rate']
+    refresh_rate = config('ui', 'refresh_rate')
 
     return redirect(url_for(
         'static', filename='index.html', refresh=refresh_rate))
@@ -32,8 +32,8 @@ def serve_image(image_id):
     '''Serve the preview image with the given id
     '''
     try:
-        preview_dir = config()['capture']['preview_dir']
-        filepath = config()['capture']['preview'][image_id]
+        preview_dir = config('capture', 'preview_dir')
+        filepath = config('capture', 'preview')[image_id]
         filepath = filepath.replace('{{previewdir}}', preview_dir)
         filepath = os.path.abspath(filepath)
         if os.path.isfile(filepath):

--- a/pyca/ui/jsonapi.py
+++ b/pyca/ui/jsonapi.py
@@ -41,7 +41,7 @@ def get_name():
     '''Serve the name of the capure agent via json.
     '''
     return make_response(
-        jsonify({'meta': {'name': config()['agent']['name']}}))
+        jsonify({'meta': {'name': config('agent', 'name')}}))
 
 
 @app.route('/api/previews')
@@ -51,8 +51,8 @@ def get_images():
     '''Serve the list of preview images via json.
     '''
     # Get IDs of existing preview images
-    preview = config()['capture']['preview']
-    previewdir = config()['capture']['preview_dir']
+    preview = config('capture', 'preview')
+    previewdir = config('capture', 'preview_dir')
     preview = [p.replace('{{previewdir}}', previewdir) for p in preview]
     preview = zip(preview, range(len(preview)))
 
@@ -184,7 +184,7 @@ def metrics(dbs):
     json.'''
     # Get Disk Usage
     # If the capture directory do not exists, use the parent directory.
-    directory = config()['capture']['directory']
+    directory = config('capture', 'directory')
     if not os.path.exists(directory):
         directory = os.path.abspath(os.path.join(directory, os.pardir))
     total, used, free = shutil.disk_usage(directory)
@@ -205,7 +205,7 @@ def metrics(dbs):
         })
     # Get Upstream State
     state = dbs.query(UpstreamState).filter(
-        UpstreamState.url == config()['server']['url']).first()
+        UpstreamState.url == config('server', 'url')).first()
     last_synchronized = state.last_synced.isoformat() if state else None
     return make_response(jsonify(
         {'meta': {

--- a/pyca/ui/utils.py
+++ b/pyca/ui/utils.py
@@ -12,10 +12,10 @@ def requires_auth(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         auth = request.authorization
-        if config()['ui']['password'] and not auth \
-                or auth.username != config()['ui']['username'] \
-                or auth.password != config()['ui']['password']:
-            return Response('pyCA', 401,
+        if config('ui', 'password') and not auth \
+                or auth.username != config('ui', 'username') \
+                or auth.password != config('ui', 'password'):
+            return Response('pyCA: Login required\n', 401,
                             {'WWW-Authenticate': 'Basic realm="pyCA Login"'})
         return f(*args, **kwargs)
     return decorated


### PR DESCRIPTION
Instead of having to handle the configuration dictionary (and possibly
empty values in it) directly, the patch allows to pass the configuration
keys directly to the `config` method which takes care of the rest.

This patch does not introduce any change in functionality.