### PR TITLE
Missing Capture Admin Endpoint

### DIFF
--- a/pyca/utils.py
+++ b/pyca/utils.py
@@ -126,9 +126,13 @@ def register_ca(status='idle'):
     # here.  We will just run silently in the background:
     if config('agent', 'backup_mode'):
         return
+    service_endpoint = config('service-capture.admin')
+    if not service_endpoint:
+        logger.warning('Missing endpoint for updating agent status.')
+        return
     params = [('address', config('ui', 'url')), ('state', status)]
     name = urlquote(config('agent', 'name').encode('utf-8'), safe='')
-    url = '%s/agents/%s' % (config('service-capture.admin')[0], name)
+    url = f'{service_endpoint[0]}/agents/{name}'
     try:
         response = http_request(url, params).decode('utf-8')
         if response:


### PR DESCRIPTION
If you terminate pyCA before it could establish a connection to Opencast
and retrieve the endpoint for setting the agent status, pyCA will try
setting the agent status anyway and fail along the process:

```
Traceback (most recent call last):
  File "/usr/lib64/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/lib64/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/lars/dev/pyCA/pyca/capture.py", line 211, in run
    control_loop()
  File "/home/lars/dev/pyCA/pyca/capture.py", line 189, in control_loop
    set_service_status_immediate(Service.CAPTURE, ServiceStatus.IDLE)
  File "/home/lars/dev/pyCA/pyca/utils.py", line 202, in set_service_status_immediate
    update_agent_state()
  File "/home/lars/dev/pyCA/pyca/utils.py", line 231, in update_agent_state
    register_ca(status=status)
  File "/home/lars/dev/pyCA/pyca/utils.py", line 139, in register_ca
    service_endpoint = config('service-capture.admin')[0]
TypeError: 'NoneType' object is not subscriptable
```

This patch fixes the problem, just logging a sensible warning instead.

---

_This is based on #198 to avoid conflicts._