### PR TITLE
Update Service Endpoints

### DIFF
--- a/pyca/capture.py
+++ b/pyca/capture.py
@@ -7,7 +7,7 @@
     :license: LGPL – see license.lgpl for more details.
 '''
 
-from pyca.utils import timestamp, try_mkdir, configure_service, terminate
+from pyca.utils import timestamp, try_mkdir, terminate
 from pyca.utils import set_service_status, set_service_status_immediate
 from pyca.utils import recording_state, update_event_status
 from pyca.config import config
@@ -209,5 +209,4 @@ def run():
     '''Start the capture agent.
     '''
     signal.signal(signal.SIGTERM, sigterm_handler)
-    configure_service('capture.admin')
     control_loop()

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -54,6 +54,8 @@ stderr           = boolean(default=True)
 file             = string(default='')
 level            = option('debug', 'info', 'warning', 'error', default='info')
 format           = string(default='[%(name)s:%(lineno)s:%(funcName)s()] [%(levelname)s] %(message)s')
+
+[services]
 '''  # noqa
 
 cfgspec = __CFG.split('\n')

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -7,8 +7,8 @@
     :license: LGPL – see license.lgpl for more details.
 '''
 
-from pyca.utils import http_request, configure_service, timestamp, \
-                       set_service_status_immediate, terminate
+from pyca.utils import http_request, service, timestamp, terminate, \
+                       set_service_status_immediate
 from pyca.config import config
 from pyca.db import get_session, UpcomingEvent, Service, ServiceStatus, \
     UpstreamState
@@ -66,7 +66,7 @@ def get_schedule():
     lookahead = config('agent', 'cal_lookahead') * 24 * 60 * 60
     if lookahead:
         params['cutoff'] = str((timestamp() + lookahead) * 1000)
-    uri = '%s/calendars?%s' % (config('service-scheduler')[0],
+    uri = '%s/calendars?%s' % (service('scheduler')[0],
                                urlencode(params))
     try:
         vcal = http_request(uri)
@@ -132,5 +132,4 @@ def control_loop():
 def run():
     '''Start the capture agent.
     '''
-    configure_service('scheduler')
     control_loop()

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -26,7 +26,7 @@ class TestPycaCapture(unittest.TestCase):
         config.config()['capture']['command'] = 'touch {{dir}}/{{name}}.mp4'
         config.config()['capture']['directory'] = self.cadir
         config.config()['capture']['preview'] = [preview]
-        config.config()['service-capture.admin'] = ['']
+        config.config()['services']['org.opencastproject.capture.admin'] = ['']
 
         # Mock event
         db.init()

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -24,8 +24,8 @@ class TestPycaIngest(unittest.TestCase):
         self.cadir = tempfile.mkdtemp()
         config.config('agent')['database'] = 'sqlite:///' + self.dbfile
         config.config('capture')['directory'] = self.cadir
-        config.config()['service-ingest'] = ['']
-        config.config()['service-capture.admin'] = ['']
+        config.config()['services']['org.opencastproject.ingest'] = ['']
+        config.config()['services']['org.opencastproject.capture.admin'] = ['']
 
         # Mock event
         db.init()

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -32,8 +32,8 @@ class TestPycaCapture(unittest.TestCase):
         utils.http_request = lambda x, y=False: b'xxx'
         self.fd, self.dbfile = tempfile.mkstemp()
         config.config()['agent']['database'] = 'sqlite:///' + self.dbfile
-        config.config()['service-scheduler'] = ['']
-        config.config()['service-capture.admin'] = ['']
+        config.config()['services']['org.opencastproject.scheduler'] = ['']
+        config.config()['services']['org.opencastproject.capture.admin'] = ['']
 
         # Mock event
         db.init()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ from tests.tools import should_fail, CurlMock, reload
 class TestPycaUtils(unittest.TestCase):
 
     def setUp(self):
-        config.config()['service-capture.admin'] = ['']
+        config.config()['services']['org.opencastproject.capture.admin'] = ['']
 
         # db
         self.fd, self.dbfile = tempfile.mkstemp()
@@ -52,11 +52,10 @@ class TestPycaUtils(unittest.TestCase):
         self.assertEqual(utils.ensurelist(1), [1])
         self.assertEqual(utils.ensurelist([1]), [1])
 
-    def test_configure_service(self):
+    def test_service(self):
         utils.terminate(False)
         utils.get_service = lambda x: 'x'
-        utils.configure_service('x')
-        self.assertEqual(config.config()['service-x'], 'x')
+        self.assertEqual(utils.service('x'), 'x')
 
     def test_http_request(self):
         config.config()['server']['insecure'] = True
@@ -84,8 +83,7 @@ class TestPycaUtils(unittest.TestCase):
         utils.register_ca()
 
     def test_recording_state(self):
-        utils.http_request = lambda x, y=False: b'xxx'
-        config.config()['service-capture.admin'] = ['']
+        utils.http_request = lambda x, y=False: b''
         utils.recording_state('123', 'recording')
         utils.http_request = should_fail
         utils.recording_state('123', 'recording')


### PR DESCRIPTION
This patch ensures that the capture endpoints are updated before
ingesting media to avoid accidentally trying to ingest to a service
which is offline or in maintenance mode.

This fixes #168
This fixes #166