### PR TITLE
Fix Response Encoding

### DIFF
--- a/pyca/utils.py
+++ b/pyca/utils.py
@@ -160,7 +160,7 @@ def recording_state(recording_id, status):
     url = config()['service-capture.admin'][0]
     url += '/recordings/%s' % recording_id
     try:
-        result = http_request(url, params)
+        result = http_request(url, params).decode('utf-8')
         logger.info(result)
     except pycurl.error as e:
         logger.warning('Could not set recording state to %s: %s', status, e)


### PR DESCRIPTION
The response from setting a recording status was logged as byte stream,
causing a somewhat weird log message:

    [pyca.utils:166:recording_state()] [INFO] b'65add3aa-9952-401a-9f8d-1b630d689385 set to capture_finished'

This patch properly encodes the response.