### PR TITLE
Remove Python 2 Specific Code

### DIFF
--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -7,7 +7,7 @@
     :license: LGPL – see license.lgpl for more details.
 '''
 
-from pyca.utils import http_request, configure_service, unix_ts, timestamp, \
+from pyca.utils import http_request, configure_service, timestamp, \
                        set_service_status_immediate, terminate
 from pyca.config import config
 from pyca.db import get_session, UpcomingEvent, Service, ServiceStatus, \
@@ -41,7 +41,7 @@ def parse_ical(vcal):
             if len(line) <= 1 or key == 'end':
                 continue
             if key.startswith('dt'):
-                event[key] = unix_ts(dateutil.parser.parse(line[1]))
+                event[key] = int(dateutil.parser.parse(line[1]).timestamp())
                 continue
             if not key.startswith('attach'):
                 event[key] = line[1]

--- a/pyca/utils.py
+++ b/pyca/utils.py
@@ -77,21 +77,10 @@ def get_service(service_type):
     return endpoints
 
 
-def unix_ts(dtval):
-    '''Convert datetime into a unix timestamp.
-    This is the equivalent to Python 3's int(datetime.timestamp()).
-
-    :param dt: datetime to convert
-    '''
-    epoch = datetime(1970, 1, 1, 0, 0, tzinfo=tzutc())
-    delta = (dtval - epoch)
-    return delta.days * 24 * 3600 + delta.seconds
-
-
 def timestamp():
     '''Get current unix timestamp
     '''
-    return unix_ts(datetime.now(tzutc()))
+    return int(datetime.now(tzutc()).timestamp())
 
 
 def try_mkdir(directory):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -10,10 +10,7 @@ import shutil
 import tempfile
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 from pyca import ingest, config, db, utils
 from tests.tools import should_fail, terminate_fn

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -6,10 +6,7 @@ Some helper tools for pyCA testing.
 import logging
 import pycurl
 
-try:
-    from importlib import reload  # noqa
-except ImportError:
-    from imp import reload  # noqa
+from importlib import reload  # noqa
 
 
 # Raise log level above maximum to silence logging in tests.


### PR DESCRIPTION
This patch removes some more Python 2 specific code which is now
unnecessary since we dropped Python 2 support.