### PR TITLE
Introduce Logging API

### DIFF
--- a/docs/apidocs.rst
+++ b/docs/apidocs.rst
@@ -281,3 +281,47 @@ cURL example::
       ]
     }
   }
+
+
+GET /api/logs
+-------------
+
+Get logs of pyCA in reverse order.
+Use the `?limit=100` parameter to limit the number of logs.
+It is limited per default to 50 logs.
+
+cURL example::
+
+  %curl -u admin:opencast \
+      -H 'content-type: application/vnd.api+json' \
+      'http://127.0.0.1:5000/api/logs?limit=2'
+  {
+    "data": [
+      {
+        "attributes": {
+          "created": "Thu, 25 Jun 2020 23:57:07 GMT",
+          "formatted": "[werkzeug:113:_log()] [INFO] 127.0.0.1 - - [25/Jun/2020 23:57:07] \"\u001b[37mGET /api/logs HTTP/1.1\u001b[0m\" 200 -",
+          "funcName": "_log",
+          "levelname": "INFO",
+          "lineno": 113,
+          "message": "127.0.0.1 - - [25/Jun/2020 23:57:07] \"\u001b[37mGET /api/logs HTTP/1.1\u001b[0m\" 200 -",
+          "name": "werkzeug"
+        },
+        "id": "152",
+        "type": "log"
+      },
+      {
+        "attributes": {
+          "created": "Thu, 25 Jun 2020 23:57:04 GMT",
+          "formatted": "[werkzeug:113:_log()] [INFO] 127.0.0.1 - - [25/Jun/2020 23:57:04] \"\u001b[37mGET /api/logs HTTP/1.1\u001b[0m\" 200 -",
+          "funcName": "_log",
+          "levelname": "INFO",
+          "lineno": 113,
+          "message": "127.0.0.1 - - [25/Jun/2020 23:57:04] \"\u001b[37mGET /api/logs HTTP/1.1\u001b[0m\" 200 -",
+          "name": "werkzeug"
+        },
+        "id": "151",
+        "type": "log"
+      }
+    ]
+  }

--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -222,6 +222,11 @@ password         = 'CHANGE_ME'
 # Default: ''
 #file             = ''
 
+# Make the log viewable from the ui. For this the logs are stored in the database.
+# Type: boolean
+# Default: False
+#ui               = True
+
 # Configure the log level
 # Possible values are: debug, info, warning and error
 # Default: info

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -11,6 +11,8 @@ import socket
 import sys
 from validate import Validator
 
+from pyca.logger import DatabaseHandler
+
 logger = logging.getLogger(__name__)
 
 __CFG = '''
@@ -52,6 +54,7 @@ url              = string(default='http://localhost:5000')
 syslog           = boolean(default=False)
 stderr           = boolean(default=True)
 file             = string(default='')
+ui               = boolean(default=False)
 level            = option('debug', 'info', 'warning', 'error', default='info')
 format           = string(default='[%(name)s:%(lineno)s:%(funcName)s()] [%(levelname)s] %(message)s')
 '''  # noqa
@@ -146,6 +149,8 @@ def logger_init():
         handlers.append(logging.StreamHandler(sys.stderr))
     if logconf['file']:
         handlers.append(logging.handlers.WatchedFileHandler(logconf['file']))
+    if logconf['ui']:
+        handlers.append(DatabaseHandler())
     for handler in handlers:
         handler.setFormatter(logging.Formatter(logconf['format']))
         logging.root.addHandler(handler)

--- a/pyca/db.py
+++ b/pyca/db.py
@@ -234,3 +234,35 @@ class UpstreamState(Base):
         s.merge(UpstreamState(url=url, last_synced=datetime.utcnow()))
         s.commit()
         s.close()
+
+
+class Log(Base):
+    '''Log entry'''
+    __tablename__ = 'log'
+    id = Column('id', Integer, primary_key=True)  # Only needed for the ORM
+    name = Column('name', Text)
+    levelname = Column('levelname', Text)
+    lineno = Column('lineno', Integer)
+    funcName = Column('funcName', Text)
+    created = Column('created', DateTime, index=True)
+    message = Column('message', Text)
+    formatted = Column('formatted', Text)
+
+    def serialize(self):
+        '''Serialize this object as dictionary usable for conversion to JSON.
+
+        :return: Dictionary representing this object.
+        '''
+        return {
+            'type': 'log',
+            'id': str(self.id),
+            'attributes': {
+                'name': self.name,
+                'levelname': self.levelname,
+                'lineno': self.lineno,
+                'funcName': self.funcName,
+                'created': self.created,
+                'message': self.message,
+                'formatted': self.formatted,
+            }
+        }

--- a/pyca/logger.py
+++ b/pyca/logger.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+'''
+    pyca.logger
+    ~~~~~~~~~~~
+
+    :copyright: 2020, Sven Haardiek <sven@haardiek.de>
+    :license: LGPL – see license.lgpl for more details.
+'''
+import logging
+from datetime import datetime
+
+
+class DatabaseHandler(logging.Handler):
+    '''Logging Handler which logs into the database.'''
+    def __init__(self):
+        logging.Handler.__init__(self)
+
+    def emit(self, record):
+        '''Actually log to the database.
+        Overrides the logging.Handler emit function.
+        '''
+        # delay database import to first call to circumvent circular
+        # dependency.
+        from pyca import db
+
+        session = db.get_session()
+        # format also make record.message available
+        formatted = self.format(record)
+        try:
+            session.add(
+                db.Log(
+                    name=record.name,
+                    levelname=record.levelname,
+                    lineno=record.lineno,
+                    funcName=record.funcName,
+                    created=datetime.fromtimestamp(record.created),
+                    message=record.message,
+                    formatted=formatted,
+                )
+            )
+            session.commit()
+        finally:
+            session.close()


### PR DESCRIPTION
This patch introduces a new logger capable of logging into the pyca database.
The logger is configurable via the config file.

There is also a API endpoint to receive the logs via HTTP.