### PR TITLE
Streamline YAML indent

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,3 +1,4 @@
+---
 env:
   browser: true
   es2020: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
+---
 language: python
 
 dist: bionic
 
 # https://devguide.python.org/#branchstatus
 python:
-   - 3.6
-   - 3.7
-   - 3.8
+  - 3.6
+  - 3.7
+  - 3.8
 
 addons:
   apt:
@@ -14,12 +15,12 @@ addons:
       - libgnutls28-dev
 
 before_install:
-   - pip install flake8 python-coveralls mock coverage
-   - npm ci
+  - pip install flake8 python-coveralls mock coverage
+  - npm ci
 
 script:
-   - make test
-   - make lint
+  - make test
+  - make lint
 
 after_success:
-   - coveralls
+  - coveralls


### PR DESCRIPTION
The YAML files had mixed indentation. This patch fixes this and
also add hyphens to mark the beginning of the documents.