### PR TITLE
Remove raw assert from testing

### DIFF
--- a/tests/test_agentstate.py
+++ b/tests/test_agentstate.py
@@ -33,4 +33,4 @@ class TestPycaAgentState(unittest.TestCase):
         try:
             agentstate.run()
         except Exception:
-            assert False
+            self.fail()

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -63,11 +63,8 @@ class TestPycaCapture(unittest.TestCase):
 
     def test_start_capture_recording_command_failure(self):
         config.config()['capture']['command'] = 'false'
-        try:
+        with self.assertRaises(RuntimeError):
             capture.start_capture(self.event)
-            assert False
-        except RuntimeError:
-            assert True
 
     def test_start_capture_sigterm(self):
         config.config()['capture']['command'] = 'sleep 10'
@@ -91,8 +88,7 @@ class TestPycaCapture(unittest.TestCase):
         capture.run()
 
     def test_sigterm(self):
-        try:
+        with self.assertRaises(BaseException) as e:
             capture.sigterm_handler(0, 0)
-        except BaseException as e:
-            assert e.code == 0
-            assert utils.terminate()
+        self.assertEqual(e.exception.code, 0)
+        self.assertTrue(utils.terminate())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,8 +14,5 @@ class TestPycaConfig(unittest.TestCase):
     def test_check(self):
         config.config()['server']['insecure'] = True
         config.config()['server']['certificate'] = '/xxx'
-        try:
+        with self.assertRaises(IOError):
             config.check()
-            assert False
-        except IOError:
-            assert True

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -27,7 +27,7 @@ class TestPycaDb(unittest.TestCase):
         os.remove(self.dbfile)
 
     def test_get_session(self):
-        assert 'autocommit' in db.get_session().__dict__.keys()
+        self.assertIn('autocommit', db.get_session().__dict__.keys())
 
     def test_event_data(self):
         series = u'äöüßÄÖÜ'
@@ -38,11 +38,11 @@ class TestPycaDb(unittest.TestCase):
 
         # Check data serialization
         data = e.get_data()
-        assert data['title'] == title
-        assert data['series'] == series
+        self.assertEqual(data['title'], title)
+        self.assertEqual(data['series'], series)
 
     def test_status(self):
-        assert db.Status.str(db.Status.UPCOMING) == 'upcoming'
+        self.assertEqual(db.Status.str(db.Status.UPCOMING), 'upcoming')
 
     def test_event(self):
         e = db.BaseEvent()
@@ -52,13 +52,13 @@ class TestPycaDb(unittest.TestCase):
         e.status = db.Status.UPCOMING
         e.set_data({})
 
-        assert str(e) == '<Event(start=123, uid="asd")>'
+        self.assertEqual(str(e), '<Event(start=123, uid="asd")>')
 
         e = db.RecordedEvent(e)
-        assert e.name() == 'recording-123-asd'
-        assert e.status_str() == 'upcoming'
-        assert e.serialize()['id'] == 'asd'
-        assert e.get_tracks() == []
+        self.assertEqual(e.name(), 'recording-123-asd')
+        self.assertEqual(e.status_str(), 'upcoming')
+        self.assertEqual(e.serialize()['id'], 'asd')
+        self.assertEqual(e.get_tracks(), [])
 
     def test_servicestate(self):
         s = db.ServiceStates()
@@ -66,5 +66,5 @@ class TestPycaDb(unittest.TestCase):
         s.status = 0
         s = db.ServiceStates(s)
 
-        assert s.type == 0
-        assert s.status == 0
+        self.assertEqual(s.type, 0)
+        self.assertEqual(s.status, 0)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,22 +30,22 @@ class TestPycaMain(unittest.TestCase):
         try:
             __main__.main()
         except BaseException as e:
-            assert e.code == 0
+            self.assertEqual(e.code, 0)
         sys.argv = ['pyca', '-x']
         try:
             __main__.main()
         except BaseException as e:
-            assert e.code == 1
+            self.assertEqual(e.code, 1)
         sys.argv = ['pyca', 'too', 'many', 'arguments']
         try:
             __main__.main()
         except BaseException as e:
-            assert e.code == 2
+            self.assertEqual(e.code, 2)
         sys.argv = ['pyca', 'fail']
         try:
             __main__.main()
         except BaseException as e:
-            assert e.code == 3
+            self.assertEqual(e.code, 3)
 
     def test_broken_configuration_type(self):
         configs = ('[capture]\nflavors = "x/source"\nfiles = a, b',
@@ -58,7 +58,7 @@ class TestPycaMain(unittest.TestCase):
             try:
                 __main__.main()
             except BaseException as e:
-                assert e.code == 4
+                self.assertEqual(e.code, 4)
             os.close(fd)
             os.remove(fn)
 
@@ -66,20 +66,14 @@ class TestPycaMain(unittest.TestCase):
         for mod in (agentstate, capture, ingest, schedule):
             mod.run = should_fail
             sys.argv = ['pyca', mod.__name__.split('.')[-1]]
-            try:
+            with self.assertRaises(ShouldFailException):
                 __main__.main()
-                assert False
-            except ShouldFailException:
-                assert True
 
         # Test ui start
         ui.app.run = should_fail
         sys.argv = ['pyca', 'ui']
-        try:
+        with self.assertRaises(ShouldFailException):
             __main__.main()
-            assert False
-        except ShouldFailException:
-            assert True
 
         # Test run all
         for mod in (agentstate, capture, ingest, schedule):
@@ -88,14 +82,13 @@ class TestPycaMain(unittest.TestCase):
         try:
             __main__.main()
         except Exception:
-            assert False
+            self.fail()
 
         for mod in (agentstate, capture, ingest, schedule):
             reload(mod)
 
     def test_sigterm(self):
-        try:
+        with self.assertRaises(BaseException) as e:
             __main__.sigterm_handler(0, 0)
-        except BaseException as e:
-            assert e.code == 0
-            assert utils.terminate()
+        self.assertEqual(e.exception.code, 0)
+        self.assertTrue(utils.terminate())

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -48,17 +48,17 @@ class TestPycaCapture(unittest.TestCase):
         # Failed request
         schedule.http_request = should_fail
         schedule.get_schedule()
-        assert not db.get_session().query(db.UpcomingEvent).count()
+        self.assertEqual(db.get_session().query(db.UpcomingEvent).count(), 0)
 
         # Failed parsing ical
         schedule.http_request = lambda x: ShouldFailException
         schedule.get_schedule()
-        assert not db.get_session().query(db.UpcomingEvent).count()
+        self.assertEqual(db.get_session().query(db.UpcomingEvent).count(), 0)
 
         # Get schedule
         schedule.http_request = lambda x: self.VCAL
         schedule.get_schedule()
-        assert db.get_session().query(db.UpcomingEvent).count()
+        self.assertGreater(db.get_session().query(db.UpcomingEvent).count(), 0)
 
     def test_run(self):
         schedule.terminate = terminate_fn(2)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -40,12 +40,12 @@ class TestPycaUI(unittest.TestCase):
     def test_ui(self):
         # Without authentication
         with ui.app.test_request_context():
-            assert ui.serve_image(0).status_code == 401
+            self.assertEqual(ui.serve_image(0).status_code, 401)
 
         # With authentication
         with ui.app.test_request_context(headers=self.auth):
-            assert ui.serve_image(9)[1] == 404
+            self.assertEqual(ui.serve_image(9)[1], 404)
         with ui.app.test_request_context(headers=self.auth):
             r = ui.serve_image(0)
-            assert r.status_code == 200
+            self.assertEqual(r.status_code, 200)
             r.close()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,26 +46,24 @@ class TestPycaUtils(unittest.TestCase):
         # Mock http_request method
         utils.http_request = lambda x, y=False: res
         endpoint = u'https://octestallinone.virtuos.uos.de/capture-admin'
-        assert utils.get_service('') == [endpoint]
+        self.assertEqual(utils.get_service(''), [endpoint])
 
     def test_ensurelist(self):
-        assert utils.ensurelist(1) == [1]
-        assert utils.ensurelist([1]) == [1]
+        self.assertEqual(utils.ensurelist(1), [1])
+        self.assertEqual(utils.ensurelist([1]), [1])
 
     def test_configure_service(self):
         utils.terminate(False)
         utils.get_service = lambda x: 'x'
         utils.configure_service('x')
-        assert config.config()['service-x'] == 'x'
+        self.assertEqual(config.config()['service-x'], 'x')
 
     def test_http_request(self):
         config.config()['server']['insecure'] = True
         config.config()['server']['certificate'] = 'nowhere'
-        try:
+        with self.assertRaises(Exception) as e:
             utils.http_request('http://127.0.0.1:8', [('x', 'y')])
-            assert False
-        except Exception as e:
-            assert e.args[0] == 7  # connection error
+        self.assertEqual(e.exception.args[0], 7)
 
     def test_http_request_mocked_curl(self):
         config.config()['server']['insecure'] = True
@@ -73,9 +71,8 @@ class TestPycaUtils(unittest.TestCase):
         utils.pycurl.Curl = CurlMock
         try:
             utils.http_request('http://127.0.0.1:8', [('x', 'y')])
-            assert True
         except Exception:
-            assert False
+            self.fail()
         reload(utils.pycurl)
 
     def test_register_ca(self):


### PR DESCRIPTION
This patch replaces the usage of raw `assert` during testing with the
`self.assert*` from the `unittest.TestCase` itself, since `assert` is ignored
with enabled optimization and is not meant to be used during tests.

Closes #177.