### PR TITLE
Add PyPI Description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,13 @@
 from setuptools import setup, find_packages
+import os
+
+path = os.path.abspath(os.path.dirname(__file__))
+
+
+def read(filename):
+    with open(os.path.join(path, filename), encoding='utf-8') as f:
+        return f.read()
+
 
 setup(
     name="pyca",
@@ -8,6 +17,8 @@ setup(
     author_email='lkiesow@uos.de',
     license="LGPLv3",
     url="https://github.com/opencast/pyCA",
+    long_description=read('readme.rst'),
+    long_description_content_type='text/x-rst',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
This patch adds the readme as the long description in the `setup.py` to show it
on PyPI.

Closes #207