### PR TITLE
Logging API Alternative

### DIFF
--- a/docs/apidocs.rst
+++ b/docs/apidocs.rst
@@ -281,3 +281,32 @@ cURL example::
       ]
     }
   }
+
+
+GET /api/logs
+-------------
+
+Get logs of pyCA gather via the command specified in the configuration.
+By default, this API endpoint is disabled and will return a HTTP 404 status
+code.
+
+cURL example::
+
+  %curl -u admin:opencast \
+      -H 'content-type: application/vnd.api+json' \
+      'http://127.0.0.1:5000/api/logs?limit=2'
+  {
+    "data": [
+      {
+        "attributes": {
+          "lines": [
+            "-- Logs begin at Fri 2020-04-24 23:25:38 CEST, end at Wed 2020-07-01 21:34:56 CEST. --",
+            "Jun 23 02:44:55 example.io systemd[1]: pyca.service: Succeeded.",
+            "Jun 23 02:44:55 example.io systemd[1]: Stopped PyCA."
+          ]
+        },
+        "id": "1593632272",
+        "type": "logs"
+      }
+    ]
+  }

--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -203,6 +203,14 @@ password         = 'CHANGE_ME'
 # Default: http://localhost:5000
 #url              = 'http://localhost:5000'
 
+# Command to execute for gathering logs which are then published via the
+# web API. The command is executed whenever the JSON API endpoint is
+# requested.
+# Defining no command will effectively disable the endpoint.
+# Type: string
+# Default: no command
+#log_command = 'journalctl -n 50 -u "pyca*"'
+
 
 [logging]
 

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -47,6 +47,7 @@ username         = string(default='admin')
 password         = string(default='opencast')
 refresh_rate     = integer(min=1, default=10)
 url              = string(default='http://localhost:5000')
+log_command      = string(default='')
 
 [logging]
 syslog           = boolean(default=False)


### PR DESCRIPTION
This patch is a draft for an alternative to storing all logs in the
database (#213). Instead, this patch allows to specify an arbitrary
command responsible for retrieving the logs.

While this gives us less control over the logs (e.g. it is hard to
distinguish different log level), this makes the code much simpler and
removes the burden, the logging puts on the database and the problem
that the database grows indefinitely.

This closes #213