### PR TITLE
Optionally delete recordings after Upload

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -134,6 +134,15 @@ command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -f lavfi -i si
 #exit_code        = 0
 
 
+[ingest]
+
+# Delete recordings after they have been successfully uploaded. This does only
+# apply to the content of the recording directory, not the metadata.
+# Type: boolean
+# Default: False
+#delete_after_upload = False
+
+
 [server]
 
 # Base URL of the admin server. This corresponds to the

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -34,6 +34,9 @@ sigterm_time     = integer(min=-1, default=-1)
 sigkill_time     = integer(min=-1, default=120)
 exit_code        = integer(min=0, max=255, default=0)
 
+[ingest]
+delete_after_upload = boolean(default=false)
+
 [server]
 url              = string(default='https://develop.opencast.org')
 auth_method      = option('basic', 'digest', default='digest')

--- a/pyca/ingest.py
+++ b/pyca/ingest.py
@@ -16,6 +16,7 @@ from random import randrange
 import logging
 import pycurl
 import sdnotify
+import shutil
 import time
 import traceback
 
@@ -99,6 +100,10 @@ def ingest(event):
     # Update status
     recording_state(event.uid, 'upload_finished')
     update_event_status(event, Status.FINISHED_UPLOADING)
+    if config('ingest', 'delete_after_upload'):
+        directory = event.directory()
+        logger.info("Removing uploaded event directory %s", directory)
+        shutil.rmtree(directory)
     notify.notify('STATUS=Running')
     set_service_status_immediate(Service.INGEST, ServiceStatus.IDLE)
 


### PR DESCRIPTION
This patch introduce a new feature of deleting recordings after they were
uploaded successfully. Is is disabled per default.