### PR TITLE
Optimize FontAwesome Size

### DIFF
--- a/ui/func.js
+++ b/ui/func.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import axios from 'axios';
 
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons/faExclamationTriangle'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
 library.add(faExclamationTriangle)


### PR DESCRIPTION
This patch includes just the used icon instead of the whole FontAwesome
library. This drastically reduces the overall size of JavaScript code
and source map

Before:

```
pyca/ui/static/func.96b176ae.js.map      ⚠️  1.22 MB    122ms
pyca/ui/static/func.96b176ae.js           842.18 KB    104ms
pyca/ui/static/style.29538ad4.css.map       2.98 KB      6ms
pyca/ui/static/index.html                   2.39 KB      2ms
pyca/ui/static/style.29538ad4.css           1.37 KB     12ms
```

After:

```
pyca/ui/static/func.3da2ae2f.js.map      412.96 KB    84ms
pyca/ui/static/func.3da2ae2f.js          161.66 KB    77ms
pyca/ui/static/style.29538ad4.css.map      2.98 KB    12ms
pyca/ui/static/index.html                  2.39 KB     3ms
pyca/ui/static/style.29538ad4.css          1.37 KB    13ms
```