### PR TITLE
Release Database Sessions

### DIFF
--- a/pyca/ingest.py
+++ b/pyca/ingest.py
@@ -135,11 +135,13 @@ def control_loop():
     while not terminate():
         notify.notify('WATCHDOG=1')
         # Get next recording
-        event = get_session().query(RecordedEvent)\
-                             .filter(RecordedEvent.status ==
-                                     Status.FINISHED_RECORDING).first()
+        session = get_session()
+        event = session.query(RecordedEvent)\
+                       .filter(RecordedEvent.status ==
+                               Status.FINISHED_RECORDING).first()
         if event:
             safe_start_ingest(event)
+        session.close()
         time.sleep(1.0)
     logger.info('Shutting down ingest service')
     set_service_status(Service.INGEST, ServiceStatus.STOPPED)

--- a/pyca/schedule.py
+++ b/pyca/schedule.py
@@ -11,7 +11,7 @@ from pyca.utils import http_request, service, timestamp, terminate, \
                        set_service_status_immediate
 from pyca.config import config
 from pyca.db import get_session, UpcomingEvent, Service, ServiceStatus, \
-    UpstreamState
+    UpstreamState, with_session
 from base64 import b64decode
 from datetime import datetime
 import dateutil.parser
@@ -58,7 +58,8 @@ def parse_ical(vcal):
     return events
 
 
-def get_schedule():
+@with_session
+def get_schedule(db):
     '''Try to load schedule from the Matterhorn core. Returns a valid schedule
     or None on failure.
     '''
@@ -81,7 +82,6 @@ def get_schedule():
         logger.error('Could not parse ical')
         logger.error(traceback.format_exc())
         return
-    db = get_session()
     db.query(UpcomingEvent).delete()
     for event in cal:
         # Ignore events that have already ended


### PR DESCRIPTION
This patch ensures that pyCA will release database sessions once they
are no longer needed. Not doing this has caused exceptions when using a
PostreSQL database.

This fixes #231