### PR TITLE
Use Enum

### DIFF
--- a/pyca/capture.py
+++ b/pyca/capture.py
@@ -74,7 +74,7 @@ def start_capture(upcoming_event):
     # If part files exist, its an partial recording
     p = any([glob.glob(f'{f}-part-*') for f in files])
     state = Status.PARTIAL_RECORDING if p else Status.FINISHED_RECORDING
-    logger.info("Set %s to %s", event.uid, Status.str(state))
+    logger.info("Set %s to %s", event.uid, state.name)
     update_event_status(event, state)
     recording_state(event.uid, 'capture_finished')
     set_service_status_immediate(Service.CAPTURE, ServiceStatus.IDLE)

--- a/pyca/ui/jsonapi.py
+++ b/pyca/ui/jsonapi.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 from flask import jsonify, make_response, request
 from pyca.config import config
-from pyca.db import Service, ServiceStatus, UpcomingEvent, \
-    RecordedEvent, UpstreamState
+from pyca.db import Service, UpcomingEvent, RecordedEvent, UpstreamState
 from pyca.db import with_session, Status, ServiceStates
 from pyca.ui import app
 from pyca.ui.utils import requires_auth, jsonapi_mediatype
@@ -70,10 +69,10 @@ def internal_state():
     '''Serve a json representation of internal agentstate as meta data
     '''
     data = {'services': {
-        'capture': ServiceStatus.str(get_service_status(Service.CAPTURE)),
-        'ingest': ServiceStatus.str(get_service_status(Service.INGEST)),
-        'schedule': ServiceStatus.str(get_service_status(Service.SCHEDULE)),
-        'agentstate': ServiceStatus.str(get_service_status(Service.AGENTSTATE))
+        'capture': get_service_status(Service.CAPTURE).name,
+        'ingest': get_service_status(Service.INGEST).name,
+        'schedule': get_service_status(Service.SCHEDULE).name,
+        'agentstate': get_service_status(Service.AGENTSTATE).name
     }}
     return make_response(jsonify({'meta': data}))
 
@@ -201,8 +200,8 @@ def metrics(dbs):
     services = []
     for srv in srvs:
         services.append({
-            'name': Service.str(srv.type),
-            'status': ServiceStatus.str(srv.status)
+            'name': srv.type.name,
+            'status': srv.status.name
         })
     # Get Upstream State
     state = dbs.query(UpstreamState).filter(

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -41,9 +41,6 @@ class TestPycaDb(unittest.TestCase):
         self.assertEqual(data['title'], title)
         self.assertEqual(data['series'], series)
 
-    def test_status(self):
-        self.assertEqual(db.Status.str(db.Status.UPCOMING), 'upcoming')
-
     def test_event(self):
         e = db.BaseEvent()
         e.uid = 'asd'
@@ -56,7 +53,7 @@ class TestPycaDb(unittest.TestCase):
 
         e = db.RecordedEvent(e)
         self.assertEqual(e.name(), 'recording-123-asd')
-        self.assertEqual(e.status_str(), 'upcoming')
+        self.assertEqual(e.status.name, 'UPCOMING')
         self.assertEqual(e.serialize()['id'], 'asd')
         self.assertEqual(e.get_tracks(), [])
 

--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -66,8 +66,7 @@ class TestPycaRestInterface(unittest.TestCase):
             meta = json.loads(response.data.decode('utf-8'))['meta']
             for service, status in meta['services'].items():
                 self.assertTrue(hasattr(db.Service, service.upper()))
-                self.assertEqual(status, db.ServiceStatus.str(
-                    db.ServiceStatus.STOPPED))
+                self.assertEqual(status, db.ServiceStatus.STOPPED.name)
 
     def test_events(self):
         # Without authentication


### PR DESCRIPTION
This patch uses Python's internal enum class instead of building our
own which is now possible since we require a recent Python version.

This fixes #126