### PR TITLE
Database Initialization

### DIFF
--- a/pyca/__main__.py
+++ b/pyca/__main__.py
@@ -12,6 +12,7 @@ import multiprocessing
 import signal
 import sys
 from pyca import capture, config, schedule, ingest, ui, agentstate, utils
+from pyca.db import get_session
 
 USAGE = '''
 Usage %s [OPTIONS] COMMAND
@@ -101,6 +102,8 @@ def main():
     cmd = (args + ['run'])[0]
 
     if cmd == 'run':
+        # ensure database is created first
+        get_session().close()
         run_all(schedule, capture, ingest, agentstate)
     elif cmd == 'schedule':
         schedule.run()


### PR DESCRIPTION
When all services are started simultaneously with no existing database,
it may happen that multiple services try creating the database structure
and some of them fail which causes the entire service to fail.

This patch ensures that the database structure is created before
starting the services removing the problem when starting all services
with pyCA's main method.

The problem can still appear when services are handled separately but
that is far less likely and there are usually safeguards in place – e.g.
systemd will restart the failed service which will automatically fix
the problem as well.