### PR TITLE
Switch to coverally-python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
       - libgnutls28-dev
 
 before_install:
-  - pip install flake8 python-coveralls mock coverage
+  - pip install flake8 coveralls mock coverage
   - npm ci
 
 script:


### PR DESCRIPTION
This patch switches to the coveralls-python [1] library since the
formerly used library is still not compatible with recent versions of
coverage.

[1] https://github.com/coveralls-clients/coveralls-python