### PR TITLE
Metrics Content Type

### DIFF
--- a/pyca/ui/jsonapi.py
+++ b/pyca/ui/jsonapi.py
@@ -179,6 +179,7 @@ def modify_event(db, uid):
 
 @app.route('/api/metrics', methods=['GET'])
 @requires_auth
+@jsonapi_mediatype
 @with_session
 def metrics(dbs):
     '''Serve several metrics about the pyCA services and the machine via

--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -75,6 +75,22 @@ class TestPycaRestInterface(unittest.TestCase):
             data = json.loads(response.data.decode('utf-8'))
             self.assertEqual(data['meta']['name'], 'a')
 
+    def test_metrics(self):
+        # Without authentication
+        with ui.app.test_request_context():
+            self.assertEqual(ui.jsonapi.metrics().status_code, 401)
+
+        # With authentication
+        with ui.app.test_request_context(headers=self.headers):
+            response = ui.jsonapi.metrics()
+            self.assertEqual(
+                response.headers['Content-Type'], self.content_type)
+            self.assertEqual(response.status_code, 200)
+            keys = json.loads(response.data.decode('utf-8'))['meta'].keys()
+            expect = {'disk_usage_in_bytes', 'load', 'memory_usage_in_bytes',
+                      'services', 'upstream'}
+            self.assertEqual(set(keys), expect)
+
     def test_mediatype_param(self):
         # JSONAPI must respond with 415 when mediatype parameters are present
         param_headers = self.headers.copy()


### PR DESCRIPTION
This patch fixes the content type of the metrics endpoint's response
which was incorrect according to JSONAPI.