### PR TITLE
Fix Logs in Python 3.6

### DIFF
--- a/pyca/ui/jsonapi.py
+++ b/pyca/ui/jsonapi.py
@@ -246,7 +246,8 @@ def logs():
     if not cmd:
         return make_error_response('Logs are disabled.', 404)
 
-    logs = subprocess.run(cmd, shell=True, check=True, capture_output=True)\
+    logs = subprocess.run(cmd, shell=True, check=True, stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT)\
         .stdout\
         .decode('utf-8')\
         .rstrip()\

--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -75,6 +75,27 @@ class TestPycaRestInterface(unittest.TestCase):
             data = json.loads(response.data.decode('utf-8'))
             self.assertEqual(data['meta']['name'], 'a')
 
+    def test_logs(self):
+        # Without authentication
+        with ui.app.test_request_context():
+            self.assertEqual(ui.jsonapi.logs().status_code, 401)
+
+        # With authentication but without command
+        with ui.app.test_request_context(headers=self.headers):
+            self.assertEqual(ui.jsonapi.logs().status_code, 404)
+
+        config.config()['ui']['log_command'] = 'echo test'
+
+        # With authentication
+        with ui.app.test_request_context(headers=self.headers):
+            response = ui.jsonapi.logs()
+            self.assertEqual(
+                response.headers['Content-Type'], self.content_type)
+            self.assertEqual(response.status_code, 200)
+            data = json.loads(response.data.decode('utf-8'))
+            self.assertEqual(len(data['data']), 1)
+            self.assertEqual(data['data'][0]['attributes']['lines'], ['test'])
+
     def test_metrics(self):
         # Without authentication
         with ui.app.test_request_context():


### PR DESCRIPTION
This patch fixes a problem with the logs endpoint which was using a
`subprocess.run()` keyword argument introduced in Python 3.7.