### PR TITLE
Consistent Shell Commands

### DIFF
--- a/docs/install/debian-based.rst
+++ b/docs/install/debian-based.rst
@@ -17,17 +17,17 @@ First, enable the repository and make sure that HTTPS connections can be used by
 
 .. code-block:: bash
 
-    apt install apt-transport-https
-    apt-key adv --fetch https://pyca.deb.opencast.org/gpg.key
-    echo "deb [arch=all] https://pyca.deb.opencast.org/opencast-pyca buster main" > \
+    % apt install apt-transport-https
+    % apt-key adv --fetch https://pyca.deb.opencast.org/gpg.key
+    % echo "deb [arch=all] https://pyca.deb.opencast.org/opencast-pyca buster main" > \
         /etc/apt/sources.list.d/opencast-pyca.list
 
 After adding the repository, we can install pyCA via package manager:
 
 .. code-block:: bash
 
-    apt update
-    apt install opencast-pyca
+    % apt update
+    % apt install opencast-pyca
 
 By default, pyCA is disabled.
 The default configuration allows you to run pyCA against the official Opencast test server.
@@ -36,8 +36,8 @@ If you do not mind, continue.
 
 To start pyCA and make sure it is automatically started after a reboot, run::
 
-    systemctl start pyca-agentstate.service pyca-capture.service pyca-ingest.service pyca-schedule.service pyca-ui.service pyca.service
-    systemctl enable pyca-agentstate.service pyca-capture.service pyca-ingest.service pyca-schedule.service pyca-ui.service pyca.service
+    % systemctl start pyca-agentstate.service pyca-capture.service pyca-ingest.service pyca-schedule.service pyca-ui.service pyca.service
+    % systemctl enable pyca-agentstate.service pyca-capture.service pyca-ingest.service pyca-schedule.service pyca-ui.service pyca.service
 
 That's it. We already have pyCA up and running.
 You can test if it's up by querying the status of the Systemd units which will list several services::
@@ -169,5 +169,5 @@ UFW
 A popular choice for a firewall is UFW.
 Run the follwing commands to allow HTTP and HTTPS::
 
-    ufw allow http
-    ufw allow https
+    % ufw allow http
+    % ufw allow https

--- a/docs/install/devel-linux.rst
+++ b/docs/install/devel-linux.rst
@@ -11,8 +11,8 @@ Get the Code
 
 Clone the git repository::
 
-  git clone https://github.com/opencast/pyCA.git
-  cd pyCA
+    % git clone https://github.com/opencast/pyCA.git
+    % cd pyCA
 
 
 Python Dependencies
@@ -29,18 +29,18 @@ PyCA also relies on some Python libraries with native C bindings.
 To allow them to be installed via ``pip`` make sure
 the base libraries are installed using a command like (Fedora, CentOS)::
 
-  dnf install gcc python3-devel libcurl-devel openssl-devel
-  export PYCURL_SSL_LIBRARY=openssl
+    % dnf install gcc python3-devel libcurl-devel openssl-devel
+    % export PYCURL_SSL_LIBRARY=openssl
 
 or (Debian, Ubuntu)::
 
-  apt install git python3 python3-venv libcurl4-openssl-dev libssl-dev gcc python3-dev
+    % apt install git python3 python3-venv libcurl4-openssl-dev libssl-dev gcc python3-dev
 
 Next, create and enable a virtual environment and install the Python dependencies::
 
-  python3 -m venv venv
-  . ./venv/bin/activate
-  pip install -r requirements.txt
+    % python3 -m venv venv
+    % . ./venv/bin/activate
+    % pip install -r requirements.txt
 
 Make sure to always enable your virtual environment before starting pyCA.
 
@@ -50,7 +50,7 @@ To check which packages need to be installed, take a look at the `requirements.t
 
 For example, on Arch Linux, you could install the dependencies using::
 
-    pacman -S python-pycurl python-dateutil python-configobj python-sqlalchemy
+    % pacman -S python-pycurl python-dateutil python-configobj python-sqlalchemy
 
 JavaScript Dependencies
 -----------------------
@@ -58,7 +58,7 @@ JavaScript Dependencies
 PyCA uses Vue.js for the web interface.
 To install all necessary JavaScript libraries, run::
 
-  npm ci
+    % npm ci
 
 This will allow you to build the JavaScript part of the web interface.
 
@@ -75,7 +75,7 @@ The default configuration should usually work great for testing:
 
 If you want to modify the configuration (e.g. to use a different Opencast server)::
 
-  vim etc/pyca.conf
+    % vim etc/pyca.conf
 
 
 Starting pyCA
@@ -83,7 +83,7 @@ Starting pyCA
 
 You can start pyCA by running::
 
-    ./start.sh
+    % ./start.sh
 
 This start script will take an optional command allowing you to separately launch pyCA services and run them as separate processes.
 By default (or using the ``run`` command) all services except the UI are launched as a single process.
@@ -96,4 +96,4 @@ and ``start.sh`` is a convenient way of building the JavaScript code and running
 
 To list all available CLI options, run::
 
-    ./start.sh -h
+    % ./start.sh -h

--- a/docs/install/rhel-family.rst
+++ b/docs/install/rhel-family.rst
@@ -18,13 +18,13 @@ First, enable the Copr repository by executing:
 
 .. code-block:: bash
 
-    dnf copr enable lkiesow/pyca
+    % dnf copr enable lkiesow/pyca
 
 After adding the repository, we can install pyCA via package manager:
 
 .. code-block:: bash
 
-    dnf install pyca
+    % dnf install pyca
 
 By default, pyCA is disabled.
 The default configuration allows you to run pyCA against the official Opencast test server.
@@ -33,8 +33,8 @@ If you do not mind, continue.
 
 To start pyCA and make sure it is automatically started after a reboot, run::
 
-    systemctl start pyca-agentstate.service pyca-capture.service pyca-ingest.service pyca-schedule.service pyca-ui.service pyca.service
-    systemctl enable pyca-agentstate.service pyca-capture.service pyca-ingest.service pyca-schedule.service pyca-ui.service pyca.service
+    % systemctl start pyca-agentstate.service pyca-capture.service pyca-ingest.service pyca-schedule.service pyca-ui.service pyca.service
+    % systemctl enable pyca-agentstate.service pyca-capture.service pyca-ingest.service pyca-schedule.service pyca-ui.service pyca.service
 
 That's it. We already have pyCA up and running.
 You can test if it's up by querying the status of the Systemd units which will list several services::
@@ -75,7 +75,7 @@ All configuration keys are documented in the configuration file itself.
 
 After updating the configuration, make sure to restart all pyCA services::
 
-    systemctl restart pyca.service
+    % systemctl restart pyca.service
 
 
 Install Nginx
@@ -109,7 +109,7 @@ Then, edit the configuration in ``/etc/nginx/nginx.conf`` and set the server sec
 
 Next, configure SELinux to allow Nginx to relay HTTP requests to pyCA::
 
-    setsebool httpd_can_network_relay true
+    % setsebool httpd_can_network_relay true
 
 Finally, (re)start the Nginx service::
 
@@ -174,9 +174,9 @@ firewalld
 A popular choice for a firewall is firewalld which is usually installed and enabled by default.
 Run the follwing commands to allow HTTP and HTTPS::
 
-    firewall-cmd --add-service=http --permanent
-    firewall-cmd --add-service=https --permanent
+    % firewall-cmd --add-service=http --permanent
+    % firewall-cmd --add-service=https --permanent
 
 Finally, reload the set of currently active rules::
 
-    firewall-cmd --reload
+    % firewall-cmd --reload

--- a/docs/pypi.rst
+++ b/docs/pypi.rst
@@ -7,7 +7,7 @@ So you can simply call
 
 .. code-block:: bash
 
-    make pypi
+    % make pypi
 
 to build a clean package.
 

--- a/docs/user-interface.rst
+++ b/docs/user-interface.rst
@@ -12,12 +12,12 @@ For testing, it comes with a minimal built-in server:
 
 To start the test server, run (additional to pyCA)::
 
-    ./start.sh ui
+    % ./start.sh ui
 
 For a production deployment, use a WSGI server instead.
 For example, use Gunicorn by running::
 
-    gunicorn pyca.ui:app
+    % gunicorn pyca.ui:app
 
 For more information, have a look at the help option of gunicorn or go to the `Gunicorn online documentation`_.
 


### PR DESCRIPTION
This patch makes the display of shell commands in the documentation
consistent by indenting the commands with four spaces and always beginng
a command with a `%` sign.