### PR TITLE
Patch for issue 30: Adds a re-ingest button in the recording table

### DIFF
--- a/ui/func.js
+++ b/ui/func.js
@@ -26,6 +26,8 @@ var data = {
     logs: [],
 };
 
+var processing_events = [];
+
 // create_event creates entries for the event list.
 var create_event = function (event, status, id) {
     return {
@@ -33,7 +35,7 @@ var create_event = function (event, status, id) {
         'end': new Date(event.attributes.end * 1000).toLocaleString(),
         'status': status,
         'id': id,
-        'processing': false,
+        'processing': processing_events.indexOf(id) >= 0,
     };
 }
 
@@ -206,6 +208,7 @@ window.onload = function () {
                     retry_ingest: function(event) {
                         if (!event.processing) {
                             event.processing = true;
+                            processing_events.push(event.id);
                             var requestOptions = {
                                 method: "PATCH",
                                 headers: { "Content-Type": "application/vnd.api+json" },
@@ -222,7 +225,10 @@ window.onload = function () {
                                     if (response.status != 200) {throw "Error: request failed - status "; }
                                 })
                                 .catch(function(error) { console.log(error); })
-                                .finally ( update_data )
+                                .finally ( () => {
+                                    processing_events.pop(event.id);
+                                    update_data
+                                })
                         }
                     }
                 }

--- a/ui/func.js
+++ b/ui/func.js
@@ -218,11 +218,11 @@ window.onload = function () {
                             };
 
                             fetch("/api/events/" + event.id, requestOptions)
-                            .then( function(response) {
-                                if (response.status != 200) {throw "Error: request failed - status "; }
-                            })
-                            .catch(function(error) { console.log(error); })
-                            .finally ( update_data )
+                                .then( function(response) {
+                                    if (response.status != 200) {throw "Error: request failed - status "; }
+                                })
+                                .catch(function(error) { console.log(error); })
+                                .finally ( update_data )
                         }
                     }
                 }

--- a/ui/func.js
+++ b/ui/func.js
@@ -210,9 +210,9 @@ window.onload = function () {
                                     "attributes": {"status": "finished recording"},
                                     "id": event.id,
                                     "type": "event"
-                                    }]})
+                                }]})
                         };
-                        fetch("/api/events/" + event.id, requestOptions).then(function(response){
+                        fetch("/api/events/" + event.id, requestOptions).then(function(){
                             update_data;
                         })
                     }

--- a/ui/style.css
+++ b/ui/style.css
@@ -118,21 +118,17 @@ td.more:hover {
     background-color: #eee;
 }
 
-button.more {
-    cursor: pointer;
-}
-
-button.more:hover {
-    background-color: #eee;
-}
-
 div.event_status {
     display: flex;
     justify-content: space-between;
 }
 
-div.event_status span {
+div.event_status span.warning {
     color: red;
+}
+
+div.event_status span.action {
+    cursor: pointer;
 }
 
 div.logs {

--- a/ui/style.css
+++ b/ui/style.css
@@ -118,6 +118,14 @@ td.more:hover {
     background-color: #eee;
 }
 
+button.more {
+    cursor: pointer;
+}
+
+button.more:hover {
+    background-color: #eee;
+}
+
 div.event_status {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
This patch adds a re-ingest button in the recording table if the recording is in state FAILED_UPLOADING

clicking the button will change the status of the recording to FINISHED_UPLOADING by sending a request to the pyCA API.
It will modify the state of the recording via PATCH /api/events/<uid> and pyCA will automaitcally try to re-upload the recording.

this fixes #30