### PR TITLE
Ensure CodeQL can build pyCURL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: install libgnutls28-dev
+      run: |
+        sudo apt update -q
+        sudo apt install -q -y libgnutls28-dev libcurl4-gnutls-dev
+
     - name: Checkout repository
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
This patch installs the necessary libraries so that pip can successfully
build pyCURL.