### PR TITLE
Don't Upload Metadata Catalogs

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -142,6 +142,13 @@ command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -f lavfi -i si
 # Default: False
 #delete_after_upload = False
 
+# Skip ingesting metadata catalogs to Opencast. If you set this option to True,
+# Opencast will use the metadata catalogs from the scheduler service and do not
+# override these by the uploaded version from pyCA.
+# Type: boolean
+# Default: False
+# skip_catalogs   = False
+
 
 [server]
 

--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -142,12 +142,11 @@ command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -f lavfi -i si
 # Default: False
 #delete_after_upload = False
 
-# Skip ingesting metadata catalogs to Opencast. If you set this option to True,
-# Opencast will use the metadata catalogs from the scheduler service and do not
-# override these by the uploaded version from pyCA.
+# Defines if pyCA will upload dublin core catalogs to Opencast.
+# Deprecated: The option will be removed soon.
 # Type: boolean
 # Default: False
-# skip_catalogs   = False
+#upload_catalogs  = False
 
 
 [server]

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -36,6 +36,7 @@ exit_code        = integer(min=0, max=255, default=0)
 
 [ingest]
 delete_after_upload = boolean(default=false)
+skip_catalogs    = boolean(default=false)
 
 [server]
 url              = string(default='https://develop.opencast.org')

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -36,7 +36,7 @@ exit_code        = integer(min=0, max=255, default=0)
 
 [ingest]
 delete_after_upload = boolean(default=false)
-skip_catalogs    = boolean(default=false)
+upload_catalogs  = boolean(default=false)
 
 [server]
 url              = string(default='https://develop.opencast.org')

--- a/pyca/ingest.py
+++ b/pyca/ingest.py
@@ -71,6 +71,10 @@ def ingest(event):
         # Check for dublincore catalogs
         elif attachment.get('fmttype') == 'application/xml' and dcns in data:
             name = attachment.get('x-apple-filename', '').rsplit('.', 1)[0]
+            if config('ingest', 'skip_catalogs'):
+                logger.info(
+                    'Skipping adding catalog %s due to configuration', name)
+                continue
             logger.info('Adding %s DC catalog', name)
             fields = [('mediaPackage', mediapackage),
                       ('flavor', 'dublincore/%s' % name),

--- a/pyca/ingest.py
+++ b/pyca/ingest.py
@@ -68,18 +68,20 @@ def ingest(event):
         if attachment.get('x-apple-filename') == prop:
             workflow_def, workflow_config = get_config_params(data)
 
-        # Check for dublincore catalogs
-        elif attachment.get('fmttype') == 'application/xml' and dcns in data:
+        # dublin core catalogs
+        elif attachment.get('fmttype') == 'application/xml' \
+                and dcns in data \
+                and config('ingest', 'upload_catalogs'):
             name = attachment.get('x-apple-filename', '').rsplit('.', 1)[0]
-            if config('ingest', 'skip_catalogs'):
-                logger.info(
-                    'Skipping adding catalog %s due to configuration', name)
-                continue
             logger.info('Adding %s DC catalog', name)
             fields = [('mediaPackage', mediapackage),
                       ('flavor', 'dublincore/%s' % name),
                       ('dublinCore', data.encode('utf-8'))]
             mediapackage = http_request(service_url + '/addDCCatalog', fields)
+
+        else:
+            logger.info('Not uploading %s', attachment.get('x-apple-filename'))
+            continue
 
     # add track
     for (flavor, track) in event.get_tracks():


### PR DESCRIPTION
This patch makes pyCA not upload metadata catalogs by default since
Opencast holds them internally anyway.

This includes/replaces https://github.com/lkiesow/pyCA/pull/3