### PR TITLE
Added upload rate limitation option

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -161,7 +161,7 @@ command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -f lavfi -i si
 # Floating point values are not allowed. Zero value will skip upload rate limitation.
 # Type: String
 # Default: '0'
-# upload_rate = '0'
+upload_rate = '250k'
 
 
 [server]

--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -156,6 +156,13 @@ command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -f lavfi -i si
 #delay_min       = 0
 #delay_max       = 120
 
+# Limit upload rate in bytes per second. You can add the suffix m for megabyte
+# or k for kilobyte (e.g. 2500k is same as 2500000 bytes).
+# Floating point values are not allowed. Zero value will skip upload rate limitation.
+# Type: String
+# Default: '0'
+# upload_rate = '0'
+
 
 [server]
 

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -39,6 +39,7 @@ delay_max        = integer(min=0, default=0)
 delay_min        = integer(min=0, default=0)
 delete_after_upload = boolean(default=false)
 upload_catalogs  = boolean(default=false)
+upload_rate      = string(default='0')
 
 [server]
 url              = string(default='https://develop.opencast.org')
@@ -105,6 +106,20 @@ def update_configuration(cfgfile=None):
         logger.warning('Base URL ends with /. This is most likely a '
                        'configuration error. The URL should contain nothing '
                        'of the service paths.')
+    if cfg['ingest'].get('upload_rate'):
+        # Limit upload rate in bytes per second
+        upload_rate = cfg['ingest'].get('upload_rate').lower()
+        if upload_rate.endswith('m'):
+            upload_rate = upload_rate[0:-1] + '000000'
+        elif upload_rate.endswith('k'):
+            upload_rate = upload_rate[0:-1] + '000'
+        try:
+            cfg['ingest']['upload_rate'] = int(upload_rate)
+        except ValueError:
+            logger.warning(
+                'Configuration value ingest.upload_rate is invalid. '
+                'Disabling upload rate limitation.')
+            cfg['ingest']['upload_rate'] = 0
     logger.info('Configuration loaded from %s', cfgfile)
     check()
     return cfg

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -113,13 +113,7 @@ def update_configuration(cfgfile=None):
             upload_rate = upload_rate[0:-1] + '000000'
         elif upload_rate.endswith('k'):
             upload_rate = upload_rate[0:-1] + '000'
-        try:
-            cfg['ingest']['upload_rate'] = int(upload_rate)
-        except ValueError:
-            logger.warning(
-                'Configuration value ingest.upload_rate is invalid. '
-                'Disabling upload rate limitation.')
-            cfg['ingest']['upload_rate'] = 0
+        cfg['ingest']['upload_rate'] = int(upload_rate)
     logger.info('Configuration loaded from %s', cfgfile)
     check()
     return cfg

--- a/pyca/utils.py
+++ b/pyca/utils.py
@@ -49,6 +49,11 @@ def http_request(url, post_data=None):
         # Import your certificates
         curl.setopt(pycurl.CAINFO, config('server', 'certificate'))
 
+    if config('ingest', 'upload_rate') > 0:
+        curl.setopt(
+            curl.MAX_SEND_SPEED_LARGE,
+            config('ingest', 'upload_rate'))
+
     if post_data:
         curl.setopt(curl.HTTPPOST, post_data)
     curl.setopt(curl.WRITEFUNCTION, buf.write)

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -49,6 +49,7 @@ class CurlMock():
     WRITEFUNCTION = 10
     FAILONERROR = 11
     FOLLOWLOCATION = 12
+    MAX_SEND_SPEED_LARGE = 13
 
     def setopt(self, *args):
         pass


### PR DESCRIPTION
In some cases you want to limit the upload rate. This may be the case on less powerfull machines like raspberry pi SoCs.