### PR TITLE
Fix Documentation Typo

### DIFF
--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -16,7 +16,7 @@ This section contains installation guides for specific operating systems or Linu
 Configuration
 -------------
 
-Most configuration documentation is contained in the `documentation file <../etc/pyca.conf>`_.
+Most configuration documentation is contained in the `configuration file <../etc/pyca.conf>`_.
 This sections just contains a few additional notes to convey ideas behind some specific configuration settings.
 
 - `System Service (Systemd) <systemd.rst>`_


### PR DESCRIPTION
Configuration options are described in the configuration file, not the
documentation file.