### PR TITLE
Fix Coveralls Deployment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,4 +44,4 @@ jobs:
     - name: upload test coverage to coveralls
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: coveralls
+      run: coveralls --service=github


### PR DESCRIPTION
We now need to explicitly tell coveralls that we run on GitHub Actions
for it to not fail with an HTTP error response.