### PR TITLE
Document pyCA Container

### DIFF
--- a/docs/install/container.rst
+++ b/docs/install/container.rst
@@ -1,0 +1,19 @@
+Install PyCA via Container
+==========================
+
+PyCA containers will automatically be built for each release and commit.
+This can be used to easily deploy pyCA e.g. for capturing network streams.
+The containers can be found at `quay.io/repository/opencast/pyca <https://quay.io/repository/opencast/pyca>`_.
+
+
+Compose Files
+-------------
+
+Compose files to easily run pyCA containers can be found in ``init/container/``.
+For a simple example, run::
+
+    cp etc/pyca.conf init/container/pyca.conf
+    sed -i "s|#name .*|name = pyca-container|g" init/container/pyca.conf
+    docker-compose -f init/container/docker-compose.sqlite.yml up
+
+More details can be found in the `container readme file <../../init/container/README.rst>`_.

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -11,6 +11,7 @@ This section contains installation guides for specific operating systems or Linu
 - `Ubuntu <install/debian-based.rst>`_
 - `CentOS 8 <install/rhel-family.rst>`_
 - `Fedora <install/rhel-family.rst>`_
+- `Container <install/container.rst>`_
 
 
 Configuration


### PR DESCRIPTION
This patch adds a short documentation entry about the existence of pyCA
containers and how to deploy them.