### PR TITLE
Serve /api/events

### DIFF
--- a/pyca/ui/jsonapi.py
+++ b/pyca/ui/jsonapi.py
@@ -78,7 +78,7 @@ def internal_state():
     return make_response(jsonify({'meta': data}))
 
 
-@app.route('/api/events/')
+@app.route('/api/events')
 @requires_auth
 @jsonapi_mediatype
 @with_session


### PR DESCRIPTION
This patch makes the API serve /api/events directly, instead of sending
a redirect to /api/events/. This prevents requests in the user interface
and potential mixed content violations if the interface address is set
to HTTP.