### PR TITLE
Lower Required Flask Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ configobj>=5.0.0
 sqlalchemy>=0.9.8
 sdnotify>=0.3.2
 psutil>=5.0.1
-flask>=1.0.2
+flask>=0.12.2


### PR DESCRIPTION
This patch lowers the required version of Flask to a version which is
available on RHEL 8 and CentOS 8 by default.