### PR TITLE
Lower Required Flask Version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "sqlalchemy>=0.9.8",
         "sdnotify>=0.3.2",
         "psutil>=5.0.1",
-        "flask>=1.0.2",
+        "flask>=0.12.2",
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This patch lowers the required version of Flask to a version which is
available on RHEL 8 and CentOS 8 by default.

This is an extension of #322 which was missing the version for the Python
setup tools.