### PR TITLE
implemented prometheus-metrics as flask middleware at /metrics

### DIFF
--- a/pyca/db.py
+++ b/pyca/db.py
@@ -65,6 +65,12 @@ def with_session(f):
 class Constants():
 
     @classmethod
+    def values(cls):
+        for key, value in cls.__dict__.items():
+            if not key.startswith('_'):
+                yield value
+
+    @classmethod
     def str(cls, value):
         '''Convert status (id) to its string name.'''
         for k, v in cls.__dict__.items():

--- a/pyca/ui/__init__.py
+++ b/pyca/ui/__init__.py
@@ -3,7 +3,12 @@
 Simple UI telling about the current state of the capture agent.
 '''
 from flask import Flask, send_from_directory, redirect, url_for
+from prometheus_client import make_wsgi_app
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
+
 from pyca.config import config
+from pyca.ui.process_status_collector import ProcessStatusCollector
+from pyca.ui.recordings_collector import RecordingsCollector
 from pyca.ui.utils import requires_auth
 import os.path
 
@@ -12,6 +17,11 @@ app = Flask(
     __name__,
     template_folder=os.path.join(__base_dir__, 'templates'),
     static_folder=os.path.join(__base_dir__, 'static'))
+
+app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {
+    '/metrics': make_wsgi_app()
+})
+
 import pyca.ui.jsonapi  # noqa
 
 

--- a/pyca/ui/__init__.py
+++ b/pyca/ui/__init__.py
@@ -4,6 +4,7 @@ Simple UI telling about the current state of the capture agent.
 '''
 from flask import Flask, send_from_directory, redirect, url_for
 from prometheus_client import make_wsgi_app
+from pyca.ui import process_status_collector, recordings_collector # noqa
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
 from pyca.config import config

--- a/pyca/ui/__init__.py
+++ b/pyca/ui/__init__.py
@@ -7,8 +7,6 @@ from prometheus_client import make_wsgi_app
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
 from pyca.config import config
-from pyca.ui.process_status_collector import ProcessStatusCollector
-from pyca.ui.recordings_collector import RecordingsCollector
 from pyca.ui.utils import requires_auth
 import os.path
 

--- a/pyca/ui/__init__.py
+++ b/pyca/ui/__init__.py
@@ -2,11 +2,9 @@
 '''
 Simple UI telling about the current state of the capture agent.
 '''
-from flask import Flask, send_from_directory, redirect, url_for
-from prometheus_client import make_wsgi_app
+from flask import Flask, send_from_directory, redirect, url_for, make_response
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 from pyca.ui import process_status_collector, recordings_collector # noqa
-from werkzeug.middleware.dispatcher import DispatcherMiddleware
-
 from pyca.config import config
 from pyca.ui.utils import requires_auth
 import os.path
@@ -16,10 +14,6 @@ app = Flask(
     __name__,
     template_folder=os.path.join(__base_dir__, 'templates'),
     static_folder=os.path.join(__base_dir__, 'static'))
-
-app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {
-    '/metrics': make_wsgi_app()
-})
 
 import pyca.ui.jsonapi  # noqa
 
@@ -53,3 +47,11 @@ def serve_image(image_id):
     except (IndexError, KeyError):
         pass
     return '', 404
+
+
+@app.route('/metrics')
+@requires_auth
+def prometheus_metrics():
+    r = make_response(generate_latest())
+    r.content_type = CONTENT_TYPE_LATEST
+    return r

--- a/pyca/ui/process_status_collector.py
+++ b/pyca/ui/process_status_collector.py
@@ -17,35 +17,18 @@ class ProcessStatusCollector(object):
             labels=['service', 'state']
         )
 
-        service_states.add_metric(
-            ['capture'],
-            self.get_state_dict(ServiceStatus.str(get_service_status(Service.CAPTURE)))
-        )
-
-        service_states.add_metric(
-            ['ingest'],
-            self.get_state_dict(ServiceStatus.str(get_service_status(Service.INGEST)))
-        )
-
-        service_states.add_metric(
-            ['schedule'],
-            self.get_state_dict(ServiceStatus.str(get_service_status(Service.SCHEDULE)))
-        )
-
-        service_states.add_metric(
-            ['agentstate'],
-            self.get_state_dict(ServiceStatus.str(get_service_status(Service.AGENTSTATE)))
-        )
+        for service in Service.values():
+            service_states.add_metric(
+                [Service.str(service)],
+                self.get_state_dict(get_service_status(service))
+            )
 
         yield service_states
 
     @staticmethod
     def get_state_dict(state: str):
-        return {
-            'stopped': 'stopped' == state,
-            'idle': 'idle' == state,
-            'busy': 'busy' == state,
-        }
+        return {ServiceStatus.str(s): s == state
+                for s in ServiceStatus.values()}
 
 
 PROCESS_STATUS_COLLECTOR = ProcessStatusCollector()

--- a/pyca/ui/process_status_collector.py
+++ b/pyca/ui/process_status_collector.py
@@ -1,0 +1,51 @@
+from prometheus_client.metrics_core import StateSetMetricFamily
+from prometheus_client.registry import REGISTRY
+
+from pyca.db import ServiceStatus, Service
+from pyca.utils import get_service_status
+
+
+class ProcessStatusCollector(object):
+
+    def __init__(self, registry=REGISTRY):
+        registry.register(self)
+
+    def collect(self):
+        service_states = StateSetMetricFamily(
+            'pyca_service_state_info',
+            'Service State of pyCA processes',
+            labels=['service', 'state']
+        )
+
+        service_states.add_metric(
+            ['capture'],
+            self.get_state_dict(ServiceStatus.str(get_service_status(Service.CAPTURE)))
+        )
+
+        service_states.add_metric(
+            ['ingest'],
+            self.get_state_dict(ServiceStatus.str(get_service_status(Service.INGEST)))
+        )
+
+        service_states.add_metric(
+            ['schedule'],
+            self.get_state_dict(ServiceStatus.str(get_service_status(Service.SCHEDULE)))
+        )
+
+        service_states.add_metric(
+            ['agentstate'],
+            self.get_state_dict(ServiceStatus.str(get_service_status(Service.AGENTSTATE)))
+        )
+
+        yield service_states
+
+    @staticmethod
+    def get_state_dict(state: str):
+        return {
+            'stopped': 'stopped' == state,
+            'idle': 'idle' == state,
+            'busy': 'busy' == state,
+        }
+
+
+PROCESS_STATUS_COLLECTOR = ProcessStatusCollector()

--- a/pyca/ui/recordings_collector.py
+++ b/pyca/ui/recordings_collector.py
@@ -1,0 +1,71 @@
+from prometheus_client.metrics_core import GaugeMetricFamily
+from prometheus_client.registry import REGISTRY
+
+from pyca.db import get_session, RecordedEvent, UpcomingEvent, Status
+from pyca.utils import timestamp
+
+
+class RecordingsCollector(object):
+
+    def __init__(self, db=get_session(), registry=REGISTRY):
+        self.db = db
+        registry.register(self)
+
+    def collect(self):
+        '''
+        Return metrics about upcoming and recorded Events
+        '''
+        recordings = GaugeMetricFamily('pyca_events_count',
+                                       'Count of Recorded Events with different status',
+                                       labels=['type'])
+        recordings.add_metric(
+            ['upcoming'],
+            value=self.db.query(UpcomingEvent).filter(UpcomingEvent.start >= timestamp()).count()
+        )
+        recordings.add_metric(
+            ['recording'],
+            value=self.db.query(RecordedEvent).filter(RecordedEvent.status == Status.RECORDING).count()
+        )
+
+        recorded_events = self.db.query(RecordedEvent)
+
+        # Filter RecordedEvents for different Status
+        recordings.add_metric(
+            ['failed_recording'],
+            value=recorded_events.filter(RecordedEvent.status == Status.FAILED_RECORDING).count()
+        )
+
+        recordings.add_metric(
+            ['finished_recording'],
+            value=recorded_events.filter(RecordedEvent.status == Status.FINISHED_RECORDING).count()
+        )
+
+        recordings.add_metric(
+            ['uploading'],
+            value=recorded_events.filter(RecordedEvent.status == Status.UPLOADING).count()
+        )
+
+        recordings.add_metric(
+            ['failed_uploading'],
+            value=recorded_events.filter(RecordedEvent.status == Status.FAILED_UPLOADING).count()
+        )
+
+        recordings.add_metric(
+            ['finished_uploading'],
+            value=recorded_events.filter(RecordedEvent.status == Status.FINISHED_UPLOADING).count()
+        )
+
+        recordings.add_metric(
+            ['partial_recording'],
+            value=recorded_events.filter(RecordedEvent.status == Status.PARTIAL_RECORDING).count()
+        )
+
+        recordings.add_metric(
+            ['paused_after_recordings'],
+            value=recorded_events.filter(RecordedEvent.status == Status.PAUSED_AFTER_RECORDING).count()
+        )
+
+        yield recordings
+
+
+RECORDINGS_COLLECTOR = RecordingsCollector()

--- a/pyca/ui/recordings_collector.py
+++ b/pyca/ui/recordings_collector.py
@@ -2,7 +2,6 @@ from prometheus_client.metrics_core import GaugeMetricFamily
 from prometheus_client.registry import REGISTRY
 
 from pyca.db import get_session, RecordedEvent, UpcomingEvent, Status
-from pyca.utils import timestamp
 
 
 class RecordingsCollector(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sqlalchemy>=0.9.8
 sdnotify>=0.3.2
 psutil>=5.0.1
 flask>=0.12.2
+prometheus_client>=0.10.1

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "sdnotify>=0.3.2",
         "psutil>=5.0.1",
         "flask>=0.12.2",
+        "prometheus_client>=0.10.1"
     ],
     entry_points={
         'console_scripts': [

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -42,6 +42,8 @@ class TestPycaDb(unittest.TestCase):
         self.assertEqual(data['series'], series)
 
     def test_status(self):
+        for i, value in enumerate(db.Status.values()):
+            self.assertEqual(value, i + 1)
         self.assertEqual(db.Status.str(db.Status.UPCOMING), 'upcoming')
 
     def test_event(self):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -37,6 +37,22 @@ class TestPycaUI(unittest.TestCase):
         with ui.app.test_request_context(headers=self.auth):
             self.assertEqual(ui.home().status_code, 302)
 
+    def test_prometheus_metrics(self):
+        # Without authentication
+        with ui.app.test_request_context():
+            self.assertEqual(ui.prometheus_metrics().status_code, 401)
+
+        # With authentication
+        with ui.app.test_request_context(headers=self.auth):
+            r = ui.prometheus_metrics()
+            self.assertEqual(r.status_code, 200)
+            data = r.data.decode()
+            self.assertIn('pyca_service_state_info', data)
+            self.assertIn('pyca_events_count', data)
+            self.assertIn('ingest', data)
+            self.assertIn('upcoming', data)
+            r.close()
+
     def test_ui(self):
         # Without authentication
         with ui.app.test_request_context():


### PR DESCRIPTION
This Pull request is thought to add prometheus metrics to pyca. The metrics are retrievable at '/metrics'. The metrics include prometheus-client default metrics and two custom collectors to return metrics about the status of pyca services and info about upcoming and recorded events.

Changes:
- setup.py, requirements.txt: Added prometheus-client library
- pyca/ui/__init__.py: changed to include prometheus metrics as flask middleware at endpoint /metrics
- pyca/ui/process_status_collector.py: Custom Collector for pyca service status
- pyca/ui/recordings_collector.py: Custom Collector for recorded and upcoming events