### PR TITLE
Update Recording Table Width

### DIFF
--- a/ui/Event.vue
+++ b/ui/Event.vue
@@ -1,6 +1,6 @@
 <template>
     <tr>
-        <td class="title">{{ event.title }}</td>
+        <td class="title" v-bind:title=event.title>{{ event.title }}</td>
         <td>{{ event.start }}</td>
         <td>{{ event.end }}</td>
         <td>

--- a/ui/style.css
+++ b/ui/style.css
@@ -114,7 +114,7 @@ td.more:hover {
 }
 
 td.title {
-    max-width: 250px;
+    max-width: 150px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
This patch updates the column width of the main recordings table
preventing actions to be shown more or less in the status label. The
additional space is taken from the title column, which maximum width is
constricted further.

To make up for this, the complete title is now contained in a title tag
which is shown when you hover over the title cells of the table.

![Screenshot from 2021-10-01 16-14-39](https://user-images.githubusercontent.com/1008395/135636268-75010dce-75c3-408f-b0ea-8d34299d86b7.png)

This extends the work started in pull request #340