### PR TITLE
Lower required Prometheus client version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ sqlalchemy>=0.9.8
 sdnotify>=0.3.2
 psutil>=5.0.1
 flask>=0.12.2
-prometheus_client>=0.10.1
+prometheus_client>=0.9

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "sdnotify>=0.3.2",
         "psutil>=5.0.1",
         "flask>=0.12.2",
-        "prometheus_client>=0.10.1"
+        "prometheus_client>=0.9"
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This patch lowers the version requirement for the Prometheus client to
a minimum of 0.9. This version still works with no problems and is
available on CentOS 8 by default.