### PR TITLE
Missing steps in installation documentation

### DIFF
--- a/docs/install/debian-based.rst
+++ b/docs/install/debian-based.rst
@@ -17,7 +17,7 @@ First, enable the repository and make sure that HTTPS connections can be used by
 
 .. code-block:: bash
 
-    % apt install apt-transport-https
+    % apt install apt-transport-https ca-certificates gnupg
     % apt-key adv --fetch https://pyca.deb.opencast.org/gpg.key
     % echo "deb [arch=all] https://pyca.deb.opencast.org/opencast-pyca buster main" > \
         /etc/apt/sources.list.d/opencast-pyca.list

--- a/docs/install/rhel-family.rst
+++ b/docs/install/rhel-family.rst
@@ -20,7 +20,13 @@ First, enable the Copr repository by executing:
 
     % dnf copr enable lkiesow/pyca
 
-After adding the repository, we can install pyCA via package manager:
+On CentOS, RHEL, … you also want to enable EPEL:
+
+.. code-block:: bash
+
+    % dnf install epel-release
+
+After adding the repository, you can install pyCA via package manager:
 
 .. code-block:: bash
 


### PR DESCRIPTION
This patch adds some missing steps to the installation documentation for
Debian and CentOS/RHEL.