### PR TITLE
Updated ffmpeg download source URL for newer ffmpeg version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,6 @@ RUN make pypi
 FROM alpine:3.13
 LABEL maintainer="pyCA team"
 
-ENV FFMPEG_VERSION="20210527041447-N-102608-g7a879cce37"
-
 COPY --from=build /usr/local/src/dist/pyca-*.tar.gz /tmp/pyca.tar.gz
 
 RUN apk --no-cache --virtual .run-deps add \
@@ -54,7 +52,7 @@ RUN apk --no-cache --virtual .run-deps add \
       gunicorn \
       psycopg2 \
  && cd /usr/local/bin \
- && curl -sSL "https://s3.opencast.org/opencast-ffmpeg-static/ffmpeg-${FFMPEG_VERSION}.tar.xz" \
+ && curl -sSL "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz" \
      | tar xJf - --strip-components 1 --wildcards '*/ffmpeg' '*/ffprobe' \
  && apk del .build-deps \
  && rm -rf /tmp/pyca.tar.gz


### PR DESCRIPTION
This updates the version of FFmpeg used in pyCA's containers to support additional protocols.
This uses the static binaries built by John Van Sickle.

This fixes #368 