### PR TITLE
Add collector for capture devices in metrics

### DIFF
--- a/pyca/ui/__init__.py
+++ b/pyca/ui/__init__.py
@@ -4,7 +4,7 @@ Simple UI telling about the current state of the capture agent.
 '''
 from flask import Flask, send_from_directory, redirect, url_for, make_response
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
-from pyca.ui import process_status_collector, recordings_collector # noqa
+from pyca.ui import capture_devices_collector, process_status_collector, recordings_collector # noqa
 from pyca.config import config
 from pyca.ui.utils import requires_auth
 import os.path

--- a/pyca/ui/capture_devices_collector.py
+++ b/pyca/ui/capture_devices_collector.py
@@ -1,0 +1,32 @@
+from prometheus_client.metrics_core import GaugeMetricFamily
+from prometheus_client.registry import REGISTRY
+
+import glob
+
+
+class CaptureDevicesCollector(object):
+    '''Return metrics about available capture devices.
+    '''
+
+    def __init__(self, registry=REGISTRY):
+        registry.register(self)
+
+    def collect(self):
+        devices = GaugeMetricFamily(
+            'video_devices',
+            'Available video devices',
+            labels=['device']
+        )
+
+        device_list = glob.glob('/dev/video*')
+
+        for device in device_list:
+            devices.add_metric(
+                [device],
+                value=1.0
+            )
+
+        yield devices
+
+
+CAPTURE_DEVICES_COLLECTOR = CaptureDevicesCollector()


### PR DESCRIPTION
This adds an indication of available video devices in the ui's metrics for most POSIX compliant systems.
Prerequisite: Devices are listed in the system's device tree (i.e. `/dev/video*` is a valid path).

Closes pyCA #382.