### PR TITLE
Fix ui status display on macOS

### DIFF
--- a/pyca/ui/jsonapi.py
+++ b/pyca/ui/jsonapi.py
@@ -226,8 +226,8 @@ def metrics(dbs):
                 'available': memory.available,
                 'used': memory.used,
                 'free': memory.free,
-                'cached': memory.cached,
-                'buffers': memory.buffers,
+                'cached': getattr(memory, 'cached', None),
+                'buffers': getattr(memory, 'buffers', None),
             },
             'load': {
                 '1m': load_1m,


### PR DESCRIPTION
This patch enables the ui's status display to be shown for macOS users.
This is done by providing a default value for the memory attributes `cached` and `buffers`,
which do not exist on macOS.