### PR TITLE
Don't run tests on Dependabot twice

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,10 @@
 name: Test pyCA
 
 on:
-  - push
-  - pull_request
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
 
 jobs:
   test:
@@ -10,7 +12,7 @@ jobs:
     strategy:
       matrix:
         # https://endoflife.date/python
-        # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#python
+        # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#python
         python-version:
           - 3.6
           - 3.7


### PR DESCRIPTION
Tests run twice on Dependabot pull requests since they react to both the `push` and the `pull_request` action. While we want to keep the push action in general, it doesn't really help in case of Dependabot.

This patch prevents running on push actions on branches starting with `dependabot`. This should be an easy fix preventing the issue with a low likelihood of effecting anything else.