### PR TITLE
Allow Opencast service host overrides

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -172,6 +172,14 @@ upload_rate = '250k'
 # Default: https://develop.opencast.org
 url              = 'https://develop.opencast.org'
 
+# Override service hosts. This is sometimes required when the Opencast
+# servers are behind a load balancer for example.
+# Type: string
+# Default:
+#override_capture_admin_host =
+#override_ingest_host =
+#override_scheduler_host =
+
 # Analogue of -k, --insecure option in curl. Allows insercure SSL connections
 # while using HTTPS on the server.
 # Type: boolean

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -43,6 +43,9 @@ upload_rate      = string(default='0')
 
 [server]
 url              = string(default='https://develop.opencast.org')
+override_capture_admin_host = string(default='')
+override_ingest_host = string(default='')
+override_scheduler_host = string(default='')
 auth_method      = option('basic', 'digest', default='digest')
 username         = string(default='opencast_system_account')
 password         = string(default='CHANGE_ME')


### PR DESCRIPTION
Allow overriding of Opencast service hosts to enable things to work when Opencast is behind load balancers. In this situation, the endpoints returned by the services endpoint are correct for internal OC communication, but not correct when access from the CAs. 

This patch allows you to override hosts for each service to point at external load balancers.