### PR TITLE
Fix configuration without authentication

### DIFF
--- a/pyca/ui/utils.py
+++ b/pyca/ui/utils.py
@@ -11,12 +11,13 @@ from pyca.config import config
 def requires_auth(f):
     @wraps(f)
     def decorated(*args, **kwargs):
+        headers = {'WWW-Authenticate': 'Basic realm="pyCA Login"'}
         auth = request.authorization
-        if config('ui', 'password') and not auth \
-                or auth.username != config('ui', 'username') \
-                or auth.password != config('ui', 'password'):
-            return Response('pyCA: Login required\n', 401,
-                            {'WWW-Authenticate': 'Basic realm="pyCA Login"'})
+        if config('ui', 'password'):
+            auth_provided = (auth.username, auth.password) if auth else None
+            auth_expected = config('ui', 'username'), config('ui', 'password')
+            if auth_provided != auth_expected:
+                return Response('pyCA: Login required\n', 401, headers)
         return f(*args, **kwargs)
     return decorated
 


### PR DESCRIPTION
If an empty password was configured in the user interface configuration, instead of requiring no authentication, pyCA would throw an internal server error:

```
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/flask/app.py", line 2528, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/flask/app.py", line 1825, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/flask/app.py", line 1823, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lars/dev/opencast/pyCA/pyca/ui/utils.py", line 16, in decorated
    or auth.username != config('ui', 'username') \
       ^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'username'
```

This patch fixes the issue.