### PR TITLE
Fix Headless Firefox in Selenium Tests

### DIFF
--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -3,4 +3,4 @@ coverage
 coveralls
 flake8
 mock
-selenium
+selenium>=4.13.0

--- a/.github/selenium-tests
+++ b/.github/selenium-tests
@@ -46,7 +46,7 @@ def check_pyca():
 if __name__ == '__main__':
     options = webdriver.FirefoxOptions()
     if sys.argv[-1] != 'gui':
-        options.headless = True
+        options.add_argument('--headless')
     driver = webdriver.Firefox(options=options)
     check_pyca()
     driver.close()


### PR DESCRIPTION
With new versions of Selenium, the way headless mode is invoked has changed:

- https://www.selenium.dev/blog/2023/headless-is-going-away/

This pull request fixes the Selenium code so that the tests continue to work on our CI system.