### PR TITLE
Remove Coveralls

### DIFF
--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,6 +1,5 @@
 bandit
 coverage
-coveralls
 flake8
 mock
 selenium>=4.13.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,5 @@ jobs:
     - name: run user interface integration tests
       run: ./.github/selenium-tests
 
-    - name: upload test coverage to coveralls
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: coveralls --service=github
+    - name: ensure test coverage doesn't drop
+      run: coverage report --fail-under=91

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,6 @@ PyCA – Opencast Capture Agent
 .. image:: https://github.com/opencast/pyCA/workflows/Test%20pyCA/badge.svg?branch=master
     :target: https://github.com/opencast/pyCA/actions?query=workflow%3A%22Test+pyCA%22+branch%3Amaster
     :alt: Test pyCA GitHub Workflow Status
-.. image:: https://coveralls.io/repos/github/opencast/pyCA/badge.svg?branch=master
-    :target: https://coveralls.io/github/opencast/pyCA?branch=master
-    :alt: Test Coverage
 .. image:: https://img.shields.io/github/license/opencast/pyCA
     :target: https://github.com/opencast/pyCA/blob/master/license.lgpl
     :alt: LGPL-3 license


### PR DESCRIPTION
This pull request removes the coveralls service integration since it causes problems with running tests on pull requests. Instead, we just use `coverage` with a limit of 92% coverage. That should do the work and is much simpler.