### PR TITLE
Fix configuration entry for upload_rate

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -161,7 +161,7 @@ command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -f lavfi -i si
 # Floating point values are not allowed. Zero value will skip upload rate limitation.
 # Type: String
 # Default: '0'
-upload_rate = '250k'
+#upload_rate = 0
 
 
 [server]


### PR DESCRIPTION
This patch fixes the `upload_rate` setting in in the configuration which should be set to the default.