### PR TITLE
 Allow Opencast service overrides 

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -172,14 +172,6 @@ command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -f lavfi -i si
 # Default: https://develop.opencast.org
 url              = 'https://develop.opencast.org'
 
-# Override service hosts. This is sometimes required when the Opencast
-# servers are behind a load balancer for example.
-# Type: string
-# Default:
-#override_capture_admin_host =
-#override_ingest_host =
-#override_scheduler_host =
-
 # Analogue of -k, --insecure option in curl. Allows insercure SSL connections
 # while using HTTPS on the server.
 # Type: boolean
@@ -216,6 +208,16 @@ password         = 'CHANGE_ME'
 # Type: string
 # Default: ''
 #certificate     = ''
+
+
+# Override service hosts. This is sometimes required when the Opencast
+# servers are behind a load balancer for example.
+# Type: service name = string
+# Example: org.opencastproject.ingest = https://example.opencast.org/ingest
+[[service_overrides]]
+#org.opencastproject.capture.admin = https://...
+#org.opencastproject.ingest = https://...
+#org.opencastproject.scheduler = https://...
 
 
 [ui]

--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -172,6 +172,14 @@ command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -f lavfi -i si
 # Default: https://develop.opencast.org
 url              = 'https://develop.opencast.org'
 
+# Override service hosts. This is sometimes required when the Opencast
+# servers are behind a load balancer for example.
+# Type: string
+# Default:
+#override_capture_admin_host =
+#override_ingest_host =
+#override_scheduler_host =
+
 # Analogue of -k, --insecure option in curl. Allows insercure SSL connections
 # while using HTTPS on the server.
 # Type: boolean

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -43,14 +43,12 @@ upload_rate      = string(default='0')
 
 [server]
 url              = string(default='https://develop.opencast.org')
-override_capture_admin_host = string(default='')
-override_ingest_host = string(default='')
-override_scheduler_host = string(default='')
 auth_method      = option('basic', 'digest', default='digest')
 username         = string(default='opencast_system_account')
 password         = string(default='CHANGE_ME')
 insecure         = boolean(default=False)
 certificate      = string(default='')
+[[service_overrides]]
 
 [ui]
 username         = string(default='admin')

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -43,6 +43,9 @@ upload_rate      = string(default='0')
 
 [server]
 url              = string(default='https://develop.opencast.org')
+override_capture_admin_host = string(default='')
+override_ingest_host = string(default='')
+override_scheduler_host = string(default='')
 auth_method      = option('basic', 'digest', default='digest')
 username         = string(default='opencast_system_account')
 password         = string(default='CHANGE_ME')


### PR DESCRIPTION
Allow overriding of Opencast service hosts to enable things to work when Opencast is behind load balancers. In this situation, the endpoints returned by the services' endpoint are correct for internal OC communication, but not correct when access from the CAs.

This patch allows you to override services to point at external load balancers.

This is a simplification of #456