### PR TITLE
Add option to use cookies

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -209,6 +209,10 @@ password         = 'CHANGE_ME'
 # Default: ''
 #certificate     = ''
 
+# File to keep track of cookies. If not specified cookies will not be used
+# Type: string
+# Default: ''
+#cookiefile       = ''
 
 # Override service hosts. This is sometimes required when the Opencast
 # servers are behind a load balancer for example.

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -48,6 +48,7 @@ username         = string(default='opencast_system_account')
 password         = string(default='CHANGE_ME')
 insecure         = boolean(default=False)
 certificate      = string(default='')
+cookiefile       = string(default='')
 [[service_overrides]]
 
 [ui]

--- a/pyca/utils.py
+++ b/pyca/utils.py
@@ -33,6 +33,11 @@ def http_request(url, post_data=None):
     curl = pycurl.Curl()
     curl.setopt(curl.URL, url.encode('ascii', 'ignore'))
 
+    # Use cookies if configured
+    if config('server', 'cookiefile'):
+        curl.setopt(curl.COOKIEJAR, config('server', 'cookiefile'))
+        curl.setopt(curl.COOKIEFILE, config('server', 'cookiefile'))
+
     # More verbose curl calls in debug mode
     if logger.getEffectiveLevel() == logging.DEBUG:
         curl.setopt(pycurl.VERBOSE, True)


### PR DESCRIPTION
keeping track of cookies when talking to Opencast
enables use with load balancers that require them
for sticky sessions.