### PR TITLE
Activate Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
+
 - package-ecosystem: npm
-  directory: "/"
+  directory: /
   schedule:
     interval: monthly
-  open-pull-requests-limit: 10
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly


### PR DESCRIPTION
This patch adds a Dependabot configuration configuration for automatically update GitHub Actions.