### PR TITLE
Use Basic Auth by Default

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -189,18 +189,18 @@ url              = 'https://develop.opencast.org'
 #
 # Type: options
 # Allowed values: basic, digest
-# Default: digest
-#auth_method = 'digest'
+# Default: basic
+#auth_method = 'basic'
 
 # Username for the admin server
 # Type: string
-# Default: opencast_system_account
-username         = 'opencast_system_account'
+# Default: admin
+username         = 'admin'
 
 # Password for the admin server
 # Type: string
-# Default: CHANGE_ME
-password         = 'CHANGE_ME'
+# Default: opencast
+password         = 'opencast'
 
 # HTTPS certificates for verification. If signed by a certificate authority
 # through an intermediate certificate, make sure to import the whole

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -43,9 +43,9 @@ upload_rate      = string(default='0')
 
 [server]
 url              = string(default='https://develop.opencast.org')
-auth_method      = option('basic', 'digest', default='digest')
-username         = string(default='opencast_system_account')
-password         = string(default='CHANGE_ME')
+auth_method      = option('basic', 'digest', default='basic')
+username         = string(default='admin')
+password         = string(default='opencast')
 insecure         = boolean(default=False)
 certificate      = string(default='')
 [[service_overrides]]


### PR DESCRIPTION
This patch makes pyCA use HTTP Basic authentication by default for communicating with Opencast. The Digest authentication is still widely used for capture agents, but slowly becomes more obscure.

Note that this is only the default. You can still use HTTP Digest authentication in necessary.