### PR TITLE
Fix branch name

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: CodeQL
 
 on:
   push:
-    branches: master
+    branches: main
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
+    branches:
+      - main
   schedule:
     - cron: '0 14 * * 0'
 


### PR DESCRIPTION
We switched the default branch from `master` to `main` quite a while ago. Unfortunately, one GitHub Actions workflow did not get updated. This patch updates the branch name.