### PR TITLE
Clear logging handler when initializing the logger

### DIFF
--- a/pyca/config.py
+++ b/pyca/config.py
@@ -165,6 +165,8 @@ def logger_init():
         handlers.append(logging.StreamHandler(sys.stderr))
     if logconf['file']:
         handlers.append(logging.handlers.WatchedFileHandler(logconf['file']))
+    if logging.root.hasHandlers():
+        logging.root.handlers.clear()
     for handler in handlers:
         handler.setFormatter(logging.Formatter(logconf['format']))
         logging.root.addHandler(handler)


### PR DESCRIPTION
This patch clears the root logging handlers when initializing the logger.

This might be considered a quickfix. The root problem is that the configuration might be loaded twice when starting up:

1. When importing the Prometheus collectors, the configuration is loaded implicitly when accessing configuration values.
2. [`__main__.py`](https://github.com/opencast/pyCA/blob/787014731741f75479d63c54b67fca5045b7ec83/pyca/__main__.py#L93) calls `config.update_configuration` explicitly.

The result is that the list of root logging handlers contains duplicate entries. Each line is thus logged twice.

Since the config can be loaded lazily, one might remove the explicit call in `__main__.py`. However, my reasoning for this approach was that resetting the logger handlers during initialization makes sense anyway.