### PR TITLE
Add API to (re)ingest an event and enable/disable the autoingesting by using config values

### DIFF
--- a/pyca/capture.py
+++ b/pyca/capture.py
@@ -77,7 +77,14 @@ def start_capture(db, upcoming_event):
     elif config('agent', 'backup_mode'):
         state = Status.PAUSED_AFTER_RECORDING
     else:
-        state = Status.FINISHED_RECORDING
+        #Tag as:
+        # must ingest automatically after recording
+        # or must pause ingest until ask for it
+        if config('ingest', 'delay_min') >= 0 and \
+                config('ingest', 'delay_max') >= config('ingest', 'delay_min'):
+            state = Status.FINISHED_RECORDING
+        else:
+            state = Status.PAUSED_AFTER_RECORDING
 
     logger.info("Set %s to %s", event.uid, Status.str(state))
     update_event_status(event, state)

--- a/pyca/ingest.py
+++ b/pyca/ingest.py
@@ -157,10 +157,10 @@ def control_loop():
     notify.notify('READY=1')
     notify.notify('STATUS=Running')
     # The true sense of the delay values define the autoingest mode status
-    autointesting_mode = config('ingest', 'delay_max') >= config('ingest', 'delay_min')
+    autoingesting_mode = config('ingest', 'delay_max') >= config('ingest', 'delay_min')
     while not terminate():
         notify.notify('WATCHDOG=1')
-        if autointesting_mode:
+        if autoingesting_mode:
             # Get next recording
             session = get_session()
             event = session.query(RecordedEvent)\


### PR DESCRIPTION
Sometimes we need to disable the automatic ingestion of the events and ingest by API on demand.
Setting the "delay_min" config value greater than "delay_max" disables the autoingesting and puts the recorded event in "paused after recording".
Using the API call "/api/ingest/{uid}", can (re)ingest a recorded event.