### PR TITLE
Fix typo in docstring

### DIFF
--- a/pyca/db.py
+++ b/pyca/db.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     pyca.db
-    ~~~~¨~~
+    ~~~~~~~
 
     Database specification for pyCA
 '''


### PR DESCRIPTION
Corrected a typo in the docstring of `pyca/db.py`.