### PR TITLE
Fix typo in dependabot configuration for eslint patterns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,8 @@ updates:
         - "@fortawesome*"
     eslint:
       patterns:
-        - "@esline*"
-        - "eslint"
+        - "@eslint*"
+        - "eslint*"
 
 - package-ecosystem: github-actions
   directory: /


### PR DESCRIPTION
Updated the pattern to actually match both `@eslint/*` and `eslint*` packages.