### PR TITLE
Add "inputs" support to pyCA

### DIFF
--- a/etc/pyca.conf
+++ b/etc/pyca.conf
@@ -40,6 +40,13 @@
 # Default: sqlite:///pyca.db
 #database = sqlite:///pyca.db
 
+# Selectable inputs
+# A track will only be ingested if the flavor of the track matches one of the
+# selected inputs.
+# If not specified, all inputs are always selected.
+# Default: inputs = ''
+#inputs = 'presenter/source, presentation/source'
+
 
 [capture]
 
@@ -170,7 +177,7 @@ command          = 'ffmpeg -nostats -re -f lavfi -r 25 -i testsrc -f lavfi -i si
 # org.opencastproject.server.url setting of Opencast.
 # Type: string
 # Default: https://develop.opencast.org
-url              = 'https://develop.opencast.org'
+url              = 'http://localhost:8080'
 
 # Analogue of -k, --insecure option in curl. Allows insercure SSL connections
 # while using HTTPS on the server.

--- a/pyca/agentstate.py
+++ b/pyca/agentstate.py
@@ -7,7 +7,8 @@
     :license: LGPL – see license.lgpl for more details.
 '''
 
-from pyca.utils import set_service_status, update_agent_state, timestamp
+from pyca.utils import set_service_status, update_agent_state, timestamp, \
+                       update_agent_config
 from pyca.utils import terminate
 from pyca.config import config
 from pyca.db import Service, ServiceStatus
@@ -34,6 +35,7 @@ def control_loop():
 
         if not terminate():
             update_agent_state()
+            update_agent_config()
 
     logger.info('Shutting down agentstate service')
     set_service_status(Service.AGENTSTATE, ServiceStatus.STOPPED)

--- a/pyca/config.py
+++ b/pyca/config.py
@@ -20,6 +20,7 @@ update_frequency = integer(min=5, default=60)
 cal_lookahead    = integer(min=0, default=14)
 backup_mode      = boolean(default=false)
 database         = string(default='sqlite:///pyca.db')
+inputs           = force_list(default=list())
 
 [capture]
 directory        = string(default='./recordings')

--- a/pyca/utils.py
+++ b/pyca/utils.py
@@ -261,6 +261,33 @@ def update_agent_state():
     register_ca(status=status)
 
 
+def update_agent_config():
+    '''Update the current agent configuration in opencast.
+    '''
+
+    if config('agent', 'backup_mode'):
+        return
+    service_endpoint = service('capture.admin')
+    if not service_endpoint:
+        logger.warning('Missing endpoint for updating agent status.')
+        return
+
+    inputs = ",".join(config('agent', 'inputs'))
+    params = [(
+                'configuration',
+                '{\'capture.device.names\': \'' + inputs + '\'}'
+             )]
+
+    name = urlquote(config('agent', 'name').encode('utf-8'), safe='')
+    url = f'{service_endpoint[0]}/agents/{name}/configuration'
+    try:
+        response = http_request(url, params).decode('utf-8')
+        if response:
+            logger.info(response)
+    except pycurl.error as e:
+        logger.warning('Could not set configuration of agent %s: %s', name, e)
+
+
 def terminate(shutdown=None):
     '''Mark process as to be terminated.
     '''


### PR DESCRIPTION
Adds support for sending configuration to the agent configuration endpoint in Opencast.
Adds a new config option "inputs". It allows users to specifiy for a given event which tracks they would like to show up in the final recording. For example, if the agent is capable of recording both "presenter/source" and "presentation/source", a user may select only "presentation/source" as input.

The idea behind this PR was to make a demo implementation for the extended capture agent api that is currently in the works in the main repo https://github.com/opencast/opencast/pull/7114. However, pyCA cannot make use of any of the new properties/capabilities. So this just adds "inputs", which is a feature that already exists in Opencast and conversely this PR should work fine without https://github.com/opencast/opencast/pull/7114. 

This PR is very similar to #413, it just does less.